### PR TITLE
Support remote images with registry `host:port`

### DIFF
--- a/tests/api/test_images.py
+++ b/tests/api/test_images.py
@@ -592,16 +592,12 @@ class TestImageParser:
             name="library/ubuntu", tag="v10.04", owner="bob", registry="localhost:5000"
         )
 
-    @pytest.mark.xfail(
-        reason="issue #938: `_ImageNameParser.parse_remote()`: "
-        "do not fall back to `parse_as_local_image()`"
-    )
     def test_parse_remote__registry_has_port__image_in_bad_repo(self) -> None:
         my_parser = _ImageNameParser(
             default_user="alice", registry_url=URL("http://localhost:5000")
         )
         image = "localhost:9999/bob/library/ubuntu:v10.04"
-        with pytest.raises(ValueError, match="scheme 'image://' is required"):
+        with pytest.raises(ValueError, match="too many tags"):
             my_parser.parse_remote(image)
 
 

--- a/tests/api/test_parser.py
+++ b/tests/api/test_parser.py
@@ -1,8 +1,10 @@
 from typing import Callable
 
 import pytest
+from yarl import URL
 
 from neuromation.api import Client, LocalImage, RemoteImage
+from neuromation.api.parsing_utils import _get_url_authority
 
 
 _MakeClient = Callable[..., Client]
@@ -29,3 +31,23 @@ async def test_parse_remote(make_client: _MakeClient) -> None:
     assert result == RemoteImage(
         "bananas", "latest", owner="bob", registry="registry-dev.neu.ro"
     )
+
+
+def test_get_url_authority_with_explicit_port() -> None:
+    url = URL("http://example.com:8080/")
+    assert _get_url_authority(url) == "example.com:8080"
+
+
+def test_get_url_authority_with_implicit_port() -> None:
+    url = URL("http://example.com/")  # here `url.port == 80`
+    assert _get_url_authority(url) == "example.com"
+
+
+def test_get_url_authority_without_port() -> None:
+    url = URL("scheme://example.com/")  # here `url.port is None`
+    assert _get_url_authority(url) == "example.com"
+
+
+def test_get_url_authority_without_host() -> None:
+    url = URL("scheme://")
+    assert _get_url_authority(url) is None


### PR DESCRIPTION
The newest version of neuro-API `19.7.26` broke platform-monitoring: https://github.com/neuromation/platform-monitoring/pull/70

The problem was that if `registry_url` contains both host and port, still `_ImageNameParser._registry` will contain only `host` part. Thus, parser `_container_from_api`, used to parse the response for  `Jobs.run`, will try to parse an image like `localhost:5000/user/ubuntu:latest` as a local image not as remote (because it does not start with `localhost/` but starts with `localhost:5000/`).

Note: one test is still xfailed due to https://github.com/neuromation/platform-client-python/issues/938
 (it fails with a wrong message)