### PR TITLE
Drop JobDescriptor.http_url_named

### DIFF
--- a/neuromation/api/jobs.py
+++ b/neuromation/api/jobs.py
@@ -93,7 +93,6 @@ class JobDescription:
     name: Optional[str] = None
     description: Optional[str] = None
     http_url: URL = URL()
-    http_url_named: URL = URL()
     ssh_server: URL = URL()
     internal_hostname: Optional[str] = None
 
@@ -405,8 +404,7 @@ def _job_description_from_api(
         is_preemptible=res["is_preemptible"],
         name=name,
         description=description,
-        http_url=http_url,
-        http_url_named=http_url_named,
+        http_url=http_url_named or http_url,
         ssh_server=ssh_server,
         ssh_auth_server=URL(res["ssh_auth_server"]),
         internal_hostname=internal_hostname,

--- a/neuromation/cli/formatters/jobs.py
+++ b/neuromation/cli/formatters/jobs.py
@@ -48,7 +48,7 @@ class JobFormatter:
             job_alias = job.name
         else:
             job_alias = job.id
-        http_url = job.http_url_named or job.http_url
+        http_url = job.http_url
         if http_url:
             out.append(style("Http URL", bold=True) + f": {http_url}")
         out.append(style("Shortcuts", bold=True) + ":")
@@ -90,7 +90,7 @@ class JobStatusFormatter:
         result += f"Preemptible: {job_status.is_preemptible}\n"
         if job_status.internal_hostname:
             result += f"Internal Hostname: {job_status.internal_hostname}\n"
-        http_url = job_status.http_url_named or job_status.http_url
+        http_url = job_status.http_url
         if http_url:
             result = f"{result}Http URL: {http_url}\n"
         if job_status.container.http:

--- a/neuromation/cli/formatters/jobs.py
+++ b/neuromation/cli/formatters/jobs.py
@@ -90,9 +90,8 @@ class JobStatusFormatter:
         result += f"Preemptible: {job_status.is_preemptible}\n"
         if job_status.internal_hostname:
             result += f"Internal Hostname: {job_status.internal_hostname}\n"
-        http_url = job_status.http_url
-        if http_url:
-            result = f"{result}Http URL: {http_url}\n"
+        if job_status.http_url:
+            result = f"{result}Http URL: {job_status.http_url}\n"
         if job_status.container.http:
             result = (
                 f"{result}Http authentication: "

--- a/neuromation/cli/job.py
+++ b/neuromation/cli/job.py
@@ -893,7 +893,7 @@ async def upload_and_map_config(root: Root) -> Tuple[str, Volume]:
 
 
 async def browse_job(root: Root, job: JobDescription) -> None:
-    url = job.http_url_named or job.http_url
+    url = job.http_url
     if url.scheme not in ("http", "https"):
         raise RuntimeError(f"Cannot open job URL: {url}")
     log.info(f"Open job URL: {url}")

--- a/tests/cli/test_formatters.py
+++ b/tests/cli/test_formatters.py
@@ -166,7 +166,7 @@ class TestJobFormatter:
         assert click.unstyle(JobFormatter(quiet=False)(job_descr)) == expected
 
     def test_non_quiet_http_url_named(self, job_descr: JobDescription) -> None:
-        job_descr = replace(job_descr, http_url_named=URL("https://job-named.dev"))
+        job_descr = replace(job_descr, http_url=URL("https://job-named.dev"))
         expected = (
             f"Job ID: {TEST_JOB_ID} Status: {JobStatus.PENDING}\n"
             + f"Name: {TEST_JOB_NAME}\n"


### PR DESCRIPTION
Support for both `JobDescriptor.http_url_named` and `JobDescriptor.http_url` in API is pointless: the code always uses *named* version if present, unnamed otherwise.

`http_url_named` should be dropped from public API at least, if server returns `http_url_named` in result JSON it should be converted to `http_url` implicitly.

There is no sense for documenting both properties or using them by user code.