### PR TITLE
Drop obsolete and unused JobDescriptor.ssh_server

### DIFF
--- a/neuromation/api/jobs.py
+++ b/neuromation/api/jobs.py
@@ -94,7 +94,6 @@ class JobDescription:
     description: Optional[str] = None
     http_url: URL = URL()
     http_url_named: URL = URL()
-    ssh_server: URL = URL()
     internal_hostname: Optional[str] = None
 
 
@@ -394,7 +393,6 @@ def _job_description_from_api(
     )
     http_url = URL(res.get("http_url", ""))
     http_url_named = URL(res.get("http_url_named", ""))
-    ssh_server = URL(res.get("ssh_server", ""))
     internal_hostname = res.get("internal_hostname", None)
     return JobDescription(
         status=JobStatus(res["status"]),
@@ -407,7 +405,6 @@ def _job_description_from_api(
         description=description,
         http_url=http_url,
         http_url_named=http_url_named,
-        ssh_server=ssh_server,
         ssh_auth_server=URL(res["ssh_auth_server"]),
         internal_hostname=internal_hostname,
     )

--- a/tests/api/test_jobs.py
+++ b/tests/api/test_jobs.py
@@ -226,7 +226,6 @@ async def test_status_failed(
         "id": "job-id",
         "description": "This is job description, not a history description",
         "http_url": "http://my_host:8889",
-        "ssh_server": "ssh://my_host.ssh:22",
         "ssh_auth_server": "ssh://my_host.ssh:22",
         "history": {
             "created_at": "2018-08-29T12:23:13.981621+00:00",
@@ -288,7 +287,6 @@ async def test_status_with_ssh_and_http(
         "id": "job-id",
         "description": "This is job description, not a history description",
         "http_url": "http://my_host:8889",
-        "ssh_server": "ssh://my_host.ssh:22",
         "ssh_auth_server": "ssh://my_host.ssh:22",
         "history": {
             "created_at": "2018-08-29T12:23:13.981621+00:00",
@@ -369,7 +367,6 @@ async def test_job_run(
             },
         },
         "http_url": "http://my_host:8889",
-        "ssh_server": "ssh://my_host.ssh:22",
         "ssh_auth_server": "ssh://my_host.ssh:22",
         "is_preemptible": False,
     }
@@ -465,7 +462,6 @@ async def test_job_run_with_name_and_description(
             },
         },
         "http_url": "http://my_host:8889",
-        "ssh_server": "ssh://my_host.ssh:22",
         "ssh_auth_server": "ssh://my_host.ssh:22",
         "is_preemptible": False,
     }
@@ -567,7 +563,6 @@ async def test_job_run_no_volumes(
             },
         },
         "http_url": "http://my_host:8889",
-        "ssh_server": "ssh://my_host.ssh:22",
         "ssh_auth_server": "ssh://my_host.ssh:22",
         "is_preemptible": False,
     }
@@ -649,7 +644,6 @@ async def test_job_run_preemptible(
         },
         "is_preemptible": True,
         "http_url": "http://my_host:8889",
-        "ssh_server": "ssh://my_host.ssh:22",
         "ssh_auth_server": "ssh://my_host.ssh:22",
     }
 
@@ -749,7 +743,6 @@ async def test_job_run_schedule_timeout(
             },
         },
         "http_url": "http://my_host:8889",
-        "ssh_server": "ssh://my_host.ssh:22",
         "ssh_auth_server": "ssh://my_host.ssh:22",
         "is_preemptible": False,
         "schedule_timeout": 5,

--- a/tests/cli/test_formatters.py
+++ b/tests/cli/test_formatters.py
@@ -188,7 +188,6 @@ class TestJobStartProgress:
             id="test-job",
             description="test job description",
             http_url=URL("http://local.host.test/"),
-            ssh_server=URL("ssh://local.host.test:22/"),
             history=JobStatusHistory(
                 status=status,
                 reason=reason,
@@ -256,7 +255,6 @@ class TestJobOutputFormatter:
             name="test-job-name",
             description="test job description",
             http_url=URL("http://local.host.test/"),
-            ssh_server=URL("ssh://local.host.test:22/"),
             history=JobStatusHistory(
                 status=JobStatus.PENDING,
                 reason="ErrorReason",
@@ -305,7 +303,6 @@ class TestJobOutputFormatter:
             id="test-job",
             description="test job description",
             http_url=URL("http://local.host.test/"),
-            ssh_server=URL("ssh://local.host.test:22/"),
             history=JobStatusHistory(
                 status=JobStatus.PENDING,
                 reason="ErrorReason",
@@ -471,7 +468,6 @@ class TestJobOutputFormatter:
                 finished_at="",
             ),
             http_url=URL("http://local.host.test/"),
-            ssh_server=URL("ssh://local.host.test:22/"),
             container=Container(
                 command="test-command",
                 image=RemoteImage("test-image"),


### PR DESCRIPTION
The attribute used to support the old implementation of `neuro exec` but this code is dropped by the client now.
There is no sense for keeping this attr now.