### PR TITLE
Speed up uploading/downloading of file and directories.

### DIFF
--- a/CHANGELOG.D/958.feature
+++ b/CHANGELOG.D/958.feature
@@ -1,0 +1,1 @@
+`neuro storage cp` is now up to 2 times faster for a directory with many small files.


### PR DESCRIPTION
Before optimization:
1 minute for `neuro storage cp -r neuromation storage:`
1 minute for `neuro storage cp -r storage:neuromation /tmp`

After optimization:
36 seconds for `neuro storage cp -r neuromation storage:`
34 seconds for `neuro storage cp -r storage:neuromation /tmp`

For comparison:
From 22 seconds to 1 minute 16 seconds for `neuro storage load -r neuromation storage:`
18 seconds for `neuro storage load -r storage:neuromation /tmp`
7 seconds for `neuro storage cp neuromation.tar storage:`
2 seconds for `neuro storage cp storage:neuromation.tar /tmp`
