### PR TITLE
Generalize job.list() defaults

### DIFF
--- a/neuromation/api/jobs.py
+++ b/neuromation/api/jobs.py
@@ -6,7 +6,7 @@ import signal
 from contextlib import suppress
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, AsyncIterator, Dict, List, Mapping, Optional, Sequence, Set
+from typing import Any, AsyncIterator, Dict, Iterable, List, Mapping, Optional, Sequence
 
 import async_timeout
 import attr
@@ -161,20 +161,18 @@ class Jobs(metaclass=NoPublicConstructor):
     async def list(
         self,
         *,
-        statuses: Optional[Set[JobStatus]] = None,
-        name: Optional[str] = None,
-        owners: Optional[Set[str]] = None,
+        statuses: Iterable[JobStatus] = (),
+        name: str = "",
+        owners: Iterable[str] = (),
     ) -> List[JobDescription]:
         url = URL(f"jobs")
         params: MultiDict[str] = MultiDict()
-        if statuses:
-            for status in statuses:
-                params.add("status", status.value)
+        for status in statuses:
+            params.add("status", status.value)
         if name:
             params.add("name", name)
-        if owners:
-            for owner in owners:
-                params.add("owner", owner)
+        for owner in owners:
+            params.add("owner", owner)
         parser = _ImageNameParser(
             self._config.auth_token.username, self._config.cluster_config.registry_url
         )

--- a/neuromation/cli/job.py
+++ b/neuromation/cli/job.py
@@ -432,6 +432,7 @@ async def _print_logs(root: Root, job: str) -> None:
     "-d",
     "--description",
     metavar="DESCRIPTION",
+    default="",
     help="Filter out jobs by description (exact match)",
 )
 @deprecated_quiet_option


### PR DESCRIPTION
There is no reason for things like `Optional[str]` if code works equally for `None` and empty string.
Also, restricting the accepted type to `Optional[Set[str]]` is worse than more wider `Iterable[str]`. Again, empty iterable is enough mark for *not set* value, there is no need for handling `None` type.