### PR TITLE
Use `curl --fail` for trigger_e2e

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ jobs:
       - run:
           name: trigger platform-e2e tests
           command: |
-              curl -X POST --header "Content-Type: application/json" \
+              curl -X POST --fail --header "Content-Type: application/json" \
                    -d '{"branch":"master"}' \
                    https://circleci.com/api/v1.1/project/github/neuromation/platform-e2e/build\?circle-token\=${E2E_CIRCLECI_TOKEN}
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,8 +113,9 @@ jobs:
       - run:
           name: trigger platform-e2e tests
           command: |
-              curl --fail -u ${E2E_CIRCLECI_TOKEN}: -X POST --header "Content-Type: application/json" \
-                  https://circleci.com/api/v1.1/project/github/neuromation/platform-e2e/tree/master
+              curl -X POST --fail --header "Content-Type: application/json" \
+                   -d '{"branch":"master"}' \
+                   https://circleci.com/api/v1.1/project/github/neuromation/platform-e2e/build\?circle-token\=${E2E_CIRCLECI_TOKEN}
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,9 +113,8 @@ jobs:
       - run:
           name: trigger platform-e2e tests
           command: |
-              curl -X POST --fail --header "Content-Type: application/json" \
-                   -d '{"branch":"master"}' \
-                   https://circleci.com/api/v1.1/project/github/neuromation/platform-e2e/build\?circle-token\=${E2E_CIRCLECI_TOKEN}
+              curl --fail -u ${E2E_CIRCLECI_TOKEN}: -X POST --header "Content-Type: application/json" \
+                  https://circleci.com/api/v1.1/project/github/neuromation/platform-e2e/tree/master
 
 
 workflows:


### PR DESCRIPTION
Example build: https://circleci.com/gh/neuromation/platform-client-python/6288
it's green however the build was not triggered.
