### PR TITLE
Hotfix: remove annoying warning during job-name to job-ID resolution

### DIFF
--- a/CHANGELOG.D/1034.bug
+++ b/CHANGELOG.D/1034.bug
@@ -1,0 +1,1 @@
+Fix bug with job-name resolution introduced in release 19.8.19: do not print annoying warning messages if more than one job with specified name was found.

--- a/neuromation/cli/utils.py
+++ b/neuromation/cli/utils.py
@@ -461,11 +461,6 @@ async def resolve_job(
             f"{details} to a job-ID: {e}"
         )
     if jobs:
-        if len(jobs) > 1:
-            log.warning(
-                f"Found {len(jobs)} jobs matching {details}: "
-                ", ".join(job.id for job in jobs)
-            )
         job_id = jobs[-1].id
         log.debug(f"Job name '{id_or_name}' resolved to job ID '{job_id}'")
     else:


### PR DESCRIPTION
Closes https://github.com/neuromation/platform-client-python/issues/1025