### PR TITLE
Improve copying progress.

### DIFF
--- a/CHANGELOG.D/1034.feature
+++ b/CHANGELOG.D/1034.feature
@@ -1,0 +1,1 @@
+Improved displaying a progress of copying many files.

--- a/neuromation/cli/formatters/storage.py
+++ b/neuromation/cli/formatters/storage.py
@@ -743,11 +743,10 @@ class TTYProgress(BaseStorageProgress):
         )
         # clear lines to sync with writing to stderr
         self.lines = []
-        self.cur_dir = None
 
     def _append_file(self, key: URL, msg: str) -> None:
         parent = key.parent
-        if self.cur_dir != parent:
+        if self.cur_dir is not None and self.cur_dir != parent:
             self._enter_dir(parent)
         self.append(key, msg)
 

--- a/neuromation/cli/formatters/storage.py
+++ b/neuromation/cli/formatters/storage.py
@@ -757,13 +757,12 @@ class TTYProgress(BaseStorageProgress):
             if not self.lines[0][1]:
                 # top line is not a dir, drop it.
                 del self.lines[0]
+            elif self.lines[1][1]:
+                # second line is a dir, drop the first line.
+                del self.lines[0]
             else:
-                if any(line[1] for line in self.lines[1:]):
-                    # there are folder lines below
-                    del self.lines[0]
-                else:
-                    # there is only top folder line, drop next file line
-                    del self.lines[1]
+                # there is a file line under a dir line, drop the file line.
+                del self.lines[1]
         for lineno, line in enumerate(self.lines):
             self.printer.print(line[2], lineno)
 

--- a/neuromation/cli/formatters/storage.py
+++ b/neuromation/cli/formatters/storage.py
@@ -701,9 +701,9 @@ class TTYProgress(BaseStorageProgress):
             click.echo(f"Copy {src_label} => {dst_label}")
 
     def enter(self, data: StorageProgressEnterDir) -> None:
-        self._enter(data.src)
+        self._enter_dir(data.src)
 
-    def _enter(self, src: URL) -> None:
+    def _enter_dir(self, src: URL) -> None:
         fmt_src = self.fmt_url(src, FileStatusType.DIRECTORY, half=False)
         self.append(src, f"{fmt_src} ...", is_dir=True)
         self.cur_dir = src
@@ -748,7 +748,7 @@ class TTYProgress(BaseStorageProgress):
     def _append_file(self, key: URL, msg: str) -> None:
         parent = key.parent
         if self.cur_dir != parent:
-            self._enter(parent)
+            self._enter_dir(parent)
         self.append(key, msg)
 
     def append(self, key: URL, msg: str, is_dir: bool = False) -> None:

--- a/neuromation/cli/formatters/storage.py
+++ b/neuromation/cli/formatters/storage.py
@@ -720,7 +720,7 @@ class TTYProgress(BaseStorageProgress):
         progress = 0
         current = self.fmt_size(0)
         total = self.fmt_size(data.size)
-        self.append(data.src, f"{src} [{progress:.2f}%] {current} of {total}")
+        self._append_file(data.src, f"{src} [{progress:.2f}%] {current} of {total}")
 
     def complete(self, data: StorageProgressComplete) -> None:
         src = self.fmt_str(data.src.name, FileStatusType.FILE)

--- a/tests/cli/test_storage_progress.py
+++ b/tests/cli/test_storage_progress.py
@@ -167,22 +167,26 @@ def test_tty_progress(capsys: Any) -> None:
     assert captured.out == f"Copy 'file:///abc' => 'storage:xyz'\n"
 
     report.enter(StorageProgressEnterDir(src, dst))
-    assert unstyle(report) == ["'file:///abc'"]
+    assert unstyle(report) == ["'file:///abc' ..."]
 
     report.start(StorageProgressStart(src_f, dst_f, 600))
-    assert unstyle(report) == ["'file:///abc'", "'file.txt' [0.00%] 0B of 600B"]
+    assert unstyle(report) == ["'file:///abc' ...", "'file.txt' [0.00%] 0B of 600B"]
 
     report.step(StorageProgressStep(src_f, dst_f, 300, 600))
-    assert unstyle(report) == ["'file:///abc'", "'file.txt' [50.00%] 300B of 600B"]
+    assert unstyle(report) == ["'file:///abc' ...", "'file.txt' [50.00%] 300B of 600B"]
 
     report.step(StorageProgressStep(src_f, dst_f, 400, 600))
-    assert unstyle(report) == ["'file:///abc'", "'file.txt' [66.67%] 400B of 600B"]
+    assert unstyle(report) == ["'file:///abc' ...", "'file.txt' [66.67%] 400B of 600B"]
 
     report.complete(StorageProgressComplete(src_f, dst_f, 600))
-    assert unstyle(report) == ["'file:///abc'", "'file.txt' 600B"]
+    assert unstyle(report) == ["'file:///abc' ...", "'file.txt' 600B"]
 
     report.leave(StorageProgressLeaveDir(src, dst))
-    assert unstyle(report) == ["'file:///abc'", "'file.txt' 600B"]
+    assert unstyle(report) == [
+        "'file:///abc' ...",
+        "'file.txt' 600B",
+        "'file:///abc' DONE",
+    ]
 
 
 def test_tty_verbose(capsys: Any) -> None:
@@ -207,63 +211,68 @@ def test_tty_nested() -> None:
     dst2_f = URL("storage:xyz/cde/file.txt")
 
     report.enter(StorageProgressEnterDir(src, dst))
-    assert unstyle(report) == ["'file:///abc'"]
+    assert unstyle(report) == ["'file:///abc' ..."]
 
     report.start(StorageProgressStart(src_f, dst_f, 600))
-    assert unstyle(report) == ["'file:///abc'", "'file.txt' [0.00%] 0B of 600B"]
+    assert unstyle(report) == ["'file:///abc' ...", "'file.txt' [0.00%] 0B of 600B"]
 
     report.step(StorageProgressStep(src_f, dst_f, 300, 600))
-    assert unstyle(report) == ["'file:///abc'", "'file.txt' [50.00%] 300B of 600B"]
+    assert unstyle(report) == ["'file:///abc' ...", "'file.txt' [50.00%] 300B of 600B"]
 
     report.step(StorageProgressStep(src_f, dst_f, 400, 600))
-    assert unstyle(report) == ["'file:///abc'", "'file.txt' [66.67%] 400B of 600B"]
+    assert unstyle(report) == ["'file:///abc' ...", "'file.txt' [66.67%] 400B of 600B"]
 
     report.complete(StorageProgressComplete(src_f, dst_f, 600))
-    assert unstyle(report) == ["'file:///abc'", "'file.txt' 600B"]
+    assert unstyle(report) == ["'file:///abc' ...", "'file.txt' 600B"]
 
     report.enter(StorageProgressEnterDir(src2, dst2))
-    assert unstyle(report) == ["'file:///abc'", "'file.txt' 600B", "'file:///abc/cde'"]
+    assert unstyle(report) == [
+        "'file:///abc' ...",
+        "'file.txt' 600B",
+        "'file:///abc/cde' ...",
+    ]
 
     report.start(StorageProgressStart(src2_f, dst2_f, 800))
     assert unstyle(report) == [
-        "'file:///abc'",
+        "'file:///abc' ...",
         "'file.txt' 600B",
-        "'file:///abc/cde'",
+        "'file:///abc/cde' ...",
         "'file.txt' [0.00%] 0B of 800B",
     ]
 
     report.step(StorageProgressStep(src2_f, dst2_f, 300, 800))
     assert unstyle(report) == [
-        "'file:///abc'",
+        "'file:///abc' ...",
         "'file.txt' 600B",
-        "'file:///abc/cde'",
+        "'file:///abc/cde' ...",
         "'file.txt' [37.50%] 300B of 800B",
     ]
 
     report.complete(StorageProgressComplete(src2_f, dst_f, 800))
     assert unstyle(report) == [
-        "'file:///abc'",
+        "'file:///abc' ...",
         "'file.txt' 600B",
-        "'file:///abc/cde'",
+        "'file:///abc/cde' ...",
         "'file.txt' 800B",
     ]
 
     report.leave(StorageProgressLeaveDir(src2, dst2))
     assert unstyle(report) == [
-        "'file:///abc'",
+        "'file:///abc' ...",
         "'file.txt' 600B",
-        "'file:///abc/cde'",
+        "'file:///abc/cde' ...",
         "'file.txt' 800B",
-        "'file:///abc'",
+        "'file:///abc/cde' DONE",
     ]
 
     report.leave(StorageProgressLeaveDir(src, dst))
     assert unstyle(report) == [
-        "'file:///abc'",
+        "'file:///abc' ...",
         "'file.txt' 600B",
-        "'file:///abc/cde'",
+        "'file:///abc/cde' ...",
         "'file.txt' 800B",
-        "'file:///abc'",
+        "'file:///abc/cde' DONE",
+        "'file:///abc' DONE",
     ]
 
 
@@ -425,19 +434,19 @@ def test_tty_append_dir() -> None:
         assert report.lines == []
         report.append(URL("a"), "a", is_dir=True)
         assert report.lines == [(URL("a"), True, "a")]
-        report.append(URL("b"), "b")
-        assert report.lines == [(URL("a"), True, "a"), (URL("b"), False, "b")]
-        report.append(URL("c"), "c")
+        report.append(URL("a/b"), "b")
+        assert report.lines == [(URL("a"), True, "a"), (URL("a/b"), False, "b")]
+        report.append(URL("a/c"), "c")
         assert report.lines == [
             (URL("a"), True, "a"),
-            (URL("b"), False, "b"),
-            (URL("c"), False, "c"),
+            (URL("a/b"), False, "b"),
+            (URL("a/c"), False, "c"),
         ]
-        report.append(URL("d"), "d")
+        report.append(URL("a/d"), "d")
         assert report.lines == [
             (URL("a"), True, "a"),
-            (URL("c"), False, "c"),
-            (URL("d"), False, "d"),
+            (URL("a/c"), False, "c"),
+            (URL("a/d"), False, "d"),
         ]
 
 

--- a/tests/cli/test_storage_progress.py
+++ b/tests/cli/test_storage_progress.py
@@ -468,7 +468,7 @@ def test_tty_append_second_dir() -> None:
         ]
         report.append(URL("d"), "d")
         assert report.lines == [
-            (URL("b"), False, "b"),
+            (URL("a"), True, "a"),
             (URL("c"), True, "c"),
             (URL("d"), False, "d"),
         ]


### PR DESCRIPTION
When start copying a directory, output `{uri} ...`.
When finish copying a directory, output `{uri} DONE`.
When update the file line, try to update it inplace if it is visible, without reordering other lines.
When the file line is not visible (a new one or was scrolled up), add it the end.
If the current directory differs from the file parent, output `{parent-uri} ...` before the file line.

Closes #1034.