### PR TITLE
Do not catch IllegalArgumentError.

### DIFF
--- a/neuromation/api/storage.py
+++ b/neuromation/api/storage.py
@@ -26,8 +26,6 @@ import aiohttp
 import attr
 from yarl import URL
 
-import neuromation
-
 from .abc import (
     AbstractFileProgress,
     AbstractRecursiveFileProgress,
@@ -445,7 +443,7 @@ class Storage(metaclass=NoPublicConstructor):
                 for retry in retries(f"Fail to create {dst}"):
                     async with retry:
                         await self.mkdir(dst, exist_ok=True)
-        except (FileExistsError, neuromation.api.core.IllegalArgumentError):
+        except FileExistsError:
             raise NotADirectoryError(errno.ENOTDIR, "Not a directory", str(dst))
         await queue.put((progress.enter, StorageProgressEnterDir(src, dst)))
         loop = asyncio.get_event_loop()

--- a/tests/api/test_storage.py
+++ b/tests/api/test_storage.py
@@ -1,5 +1,6 @@
 import asyncio
 import errno
+import json
 import os
 from filecmp import dircmp
 from pathlib import Path
@@ -89,7 +90,13 @@ async def storage_server(
                 }
             )
         elif op == "MKDIRS":
-            local_path.mkdir(parents=True, exist_ok=True)
+            try:
+                local_path.mkdir(parents=True, exist_ok=True)
+            except FileExistsError:
+                raise web.HTTPBadRequest(
+                    text=json.dumps({"error": "File exists", "errno": "EEXIST"}),
+                    content_type="application/json",
+                )
             return web.Response(status=201)
         elif op == "LISTSTATUS":
             if not local_path.exists():


### PR DESCRIPTION
The 500 code was send by the storage server when create a directory
which matches existing file. Now the 400 code is send and it is
converted to FileExistsError or other OSError on client side.