### PR TITLE
Distributed tracing

### DIFF
--- a/neuromation/api/__init__.py
+++ b/neuromation/api/__init__.py
@@ -48,6 +48,7 @@ from .jobs import (
 )
 from .parsing_utils import LocalImage, RemoteImage
 from .storage import FileStatus, FileStatusType
+from .tracing import gen_trace_id
 from .users import Action, Permission, Share
 from .utils import _ContextManager
 
@@ -98,6 +99,7 @@ __all__ = (
     "login_with_token",
     "logout",
     "ConfigError",
+    "gen_trace_id",
 )
 
 

--- a/neuromation/api/client.py
+++ b/neuromation/api/client.py
@@ -21,10 +21,13 @@ SESSION_COOKIE_MAXAGE = 5 * 60  # 5 min
 
 
 class Client(metaclass=NoPublicConstructor):
-    def __init__(self, session: aiohttp.ClientSession, config: _Config) -> None:
+    def __init__(
+        self, session: aiohttp.ClientSession, config: _Config, trace_id: Optional[str]
+    ) -> None:
         self._closed = False
         config.check_initialized()
         self._config = config
+        self._trace_id = trace_id
         self._session = session
         if time.time() - config.cookie_session.timestamp > SESSION_COOKIE_MAXAGE:
             # expired
@@ -37,7 +40,7 @@ class Client(metaclass=NoPublicConstructor):
             cookie["domain"] = config.url.raw_host
             cookie["path"] = "/"
         self._core = _Core(
-            session, self._config.url, self._config.auth_token.token, cookie
+            session, self._config.url, self._config.auth_token.token, cookie, trace_id
         )
         self._jobs = Jobs._create(self._core, self._config)
         self._storage = Storage._create(self._core, self._config)

--- a/neuromation/api/config_factory.py
+++ b/neuromation/api/config_factory.py
@@ -71,7 +71,7 @@ class Factory:
         self._path = path.expanduser()
         self._trace_configs = [_make_trace_config()]
         if trace_configs:
-            self._trace_configs += list(trace_configs)
+            self._trace_configs += trace_configs
         self._trace_id = trace_id
 
     async def get(self, *, timeout: aiohttp.ClientTimeout = DEFAULT_TIMEOUT) -> Client:

--- a/neuromation/api/images.py
+++ b/neuromation/api/images.py
@@ -48,6 +48,7 @@ class Images(metaclass=NoPublicConstructor):
             self._core.session,
             self._config.cluster_config.registry_url.with_path("/v2/"),
             self._config.auth_token.token,
+            self._core._trace_id,
             self._config.auth_token.username,
         )
 

--- a/neuromation/api/registry.py
+++ b/neuromation/api/registry.py
@@ -1,5 +1,5 @@
 import base64
-from typing import Dict
+from typing import Dict, Optional
 
 import aiohttp
 from yarl import URL
@@ -14,10 +14,15 @@ class _Registry(_Core):
     """
 
     def __init__(
-        self, session: aiohttp.ClientSession, base_url: URL, token: str, username: str
+        self,
+        session: aiohttp.ClientSession,
+        base_url: URL,
+        token: str,
+        trace_id: Optional[str],
+        username: str,
     ) -> None:
         self._username = username
-        super().__init__(session, base_url, token, None)
+        super().__init__(session, base_url, token, None, trace_id)
 
     def _auth_headers(self) -> Dict[str, str]:
         assert self._username

--- a/neuromation/api/tracing.py
+++ b/neuromation/api/tracing.py
@@ -13,7 +13,7 @@ def gen_trace_id() -> str:
 
     The id is used for distributed tracing.
     """
-    return str(binascii.hexlify(os.urandom(8)).decode("utf-8"))
+    return os.urandom(8).hex()
 
 
 def _update_headers(headers: "CIMultiDict[str]", trace_id: str, span_id: str) -> None:

--- a/neuromation/api/tracing.py
+++ b/neuromation/api/tracing.py
@@ -1,6 +1,5 @@
 # Distributed tracing support
 
-import binascii
 import os
 import types
 
@@ -9,7 +8,7 @@ from multidict import CIMultiDict
 
 
 def gen_trace_id() -> str:
-    """Returns a 64 bit UTF-8 encoded string.
+    """Return 16 random hexadecimal digits.
 
     The id is used for distributed tracing.
     """

--- a/neuromation/api/tracing.py
+++ b/neuromation/api/tracing.py
@@ -1,0 +1,42 @@
+# Distributed tracing support
+
+import binascii
+import os
+import types
+
+import aiohttp
+from multidict import CIMultiDict
+
+
+def gen_trace_id() -> str:
+    """Returns a 64 bit UTF-8 encoded string.
+
+    The id is used for distributed tracing.
+    """
+    return str(binascii.hexlify(os.urandom(8)).decode("utf-8"))
+
+
+def _update_headers(headers: "CIMultiDict[str]", trace_id: str, span_id: str) -> None:
+    """Creates dict with zipkin single header format.
+    """
+    # b3={TraceId}-{SpanId}-{SamplingState}-{ParentSpanId}
+    headers["b3"] = f"{trace_id}-{span_id}"
+
+
+async def _on_request_start(
+    session: aiohttp.ClientSession,
+    context: types.SimpleNamespace,
+    params: aiohttp.TraceRequestStartParams,
+) -> None:
+    trace_ctx = context.trace_request_ctx
+    trace_id = getattr(trace_ctx, "trace_id", None)
+    if trace_id is None:
+        return
+    span_id = gen_trace_id()
+    _update_headers(params.headers, trace_id, span_id)
+
+
+def _make_trace_config() -> aiohttp.TraceConfig:
+    trace_config = aiohttp.TraceConfig()
+    trace_config.on_request_start.append(_on_request_start)  # type: ignore
+    return trace_config

--- a/neuromation/cli/root.py
+++ b/neuromation/cli/root.py
@@ -9,7 +9,7 @@ import aiohttp
 import click
 from yarl import URL
 
-from neuromation.api import Client, Factory, Preset
+from neuromation.api import Client, Factory, Preset, gen_trace_id
 from neuromation.api.config import _Config
 from neuromation.api.config_factory import ConfigError
 
@@ -90,7 +90,9 @@ class Root:
             trace_configs = [self._create_trace_config()]
         else:
             trace_configs = None
-        self._factory = Factory(path=self.config_path, trace_configs=trace_configs)
+        self._factory = Factory(
+            path=self.config_path, trace_configs=trace_configs, trace_id=gen_trace_id()
+        )
         client = await self._factory.get(timeout=self.timeout)
 
         self._client = client

--- a/tests/api/test_core.py
+++ b/tests/api/test_core.py
@@ -35,7 +35,7 @@ async def api_factory() -> AsyncIterator[_ApiFactory]:
         ssl_context.load_verify_locations(capath=certifi.where())
         connector = aiohttp.TCPConnector(ssl=ssl_context)
         session = aiohttp.ClientSession(connector=connector)
-        api = _Core(session, url, "token", cookie)
+        api = _Core(session, url, "token", cookie, "bd7a977555f6b982")
         yield api
         await api.close()
         await session.close()

--- a/tests/api/test_jobs.py
+++ b/tests/api/test_jobs.py
@@ -242,6 +242,7 @@ async def test_save_ok(
     ]
 
     async def handler(request: web.Request) -> web.StreamResponse:
+        assert "b3" in request.headers
         encoding = "utf-8"
         response = web.StreamResponse(status=200)
         response.enable_compression(web.ContentCoding.identity)
@@ -274,6 +275,7 @@ async def test_save_commit_started_invalid_status_fails(
     ]
 
     async def handler(request: web.Request) -> web.StreamResponse:
+        assert "b3" in request.headers
         encoding = "utf-8"
         response = web.StreamResponse(status=200)
         response.enable_compression(web.ContentCoding.identity)
@@ -309,6 +311,7 @@ async def test_save_commit_started_missing_image_details_fails(
     ]
 
     async def handler(request: web.Request) -> web.StreamResponse:
+        assert "b3" in request.headers
         encoding = "utf-8"
         response = web.StreamResponse(status=200)
         response.enable_compression(web.ContentCoding.identity)

--- a/tests/api/test_storage.py
+++ b/tests/api/test_storage.py
@@ -61,6 +61,7 @@ async def storage_server(
     PREFIX_LEN = len(PREFIX)
 
     async def handler(request: web.Request) -> web.Response:
+        assert "b3" in request.headers
         op = request.query["op"]
         path = request.path
         assert path.startswith(PREFIX)
@@ -145,6 +146,7 @@ async def test_storage_ls(
     }
 
     async def handler(request: web.Request) -> web.Response:
+        assert "b3" in request.headers
         assert request.path == "/storage/user/folder"
         assert request.query == {"op": "LISTSTATUS"}
         return web.json_response(JSON)
@@ -179,6 +181,7 @@ async def test_storage_glob(
     aiohttp_server: _TestServerFactory, make_client: _MakeClient
 ) -> None:
     async def handler_home(request: web.Request) -> web.Response:
+        assert "b3" in request.headers
         assert request.path == "/storage/user/"
         assert request.query == {"op": "LISTSTATUS"}
         return web.json_response(
@@ -198,6 +201,7 @@ async def test_storage_glob(
         )
 
     async def handler_folder(request: web.Request) -> web.Response:
+        assert "b3" in request.headers
         assert request.path.rstrip("/") == "/storage/user/folder"
         assert request.query["op"] in ("GETFILESTATUS", "LISTSTATUS")
         if request.query["op"] == "GETFILESTATUS":
@@ -239,6 +243,7 @@ async def test_storage_glob(
             raise web.HTTPInternalServerError
 
     async def handler_foo(request: web.Request) -> web.Response:
+        assert "b3" in request.headers
         assert request.path == "/storage/user/folder/foo"
         assert request.query["op"] in ("GETFILESTATUS", "LISTSTATUS")
         assert request.query == {"op": "GETFILESTATUS"}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ from neuromation.api.config import (
     _PyPIVersion,
 )
 from neuromation.api.login import _ClusterConfig
+from neuromation.api.tracing import _make_trace_config
 
 
 @pytest.fixture
@@ -62,7 +63,11 @@ def cluster_config() -> _ClusterConfig:
 
 @pytest.fixture
 def make_client(token: str, auth_config: _AuthConfig) -> Callable[..., Client]:
-    def go(url_str: str, registry_url: str = "https://registry-dev.neu.ro") -> Client:
+    def go(
+        url_str: str,
+        registry_url: str = "https://registry-dev.neu.ro",
+        trace_id: str = "bd7a977555f6b982",
+    ) -> Client:
         url = URL(url_str)
         cluster_config = _ClusterConfig(
             registry_url=URL(registry_url),
@@ -89,7 +94,7 @@ def make_client(token: str, auth_config: _AuthConfig) -> Callable[..., Client]:
             cookie_session=_CookieSession.create_uninitialized(),
             version=neuromation.__version__,
         )
-        session = aiohttp.ClientSession()
-        return Client._create(session, config)
+        session = aiohttp.ClientSession(trace_configs=[_make_trace_config()])
+        return Client._create(session, config, trace_id)
 
     return go


### PR DESCRIPTION
Fixes #706

Send zipkin-compatible tracing 'b3' header to servers.
span-id is regenerated for every HTTP request, where is no choice here.
sampling-state is not sent, it is a server duty to decide what sampling rate is appropriate.
trace-id is regenerated for every request if not specified explicitly by api `Factory` construction.

CLI uses unique trace-id during the whole CLI run; it allows to merge all subsequent HTTTP calls for batch operations like recursive file uploading. 
Not sure how to achieve this for programmatic API usage; introducing additional layer just for grouping is tedious:
```
async with get() as client:
   async with client.new_span() as span():
       await span.jobs.run(....)
```

Do we need it at all?
Ideas?