### PR TITLE
Remove user's token when `--trace` is enabled

### DIFF
--- a/CHANGELOG.D/1158.feature
+++ b/CHANGELOG.D/1158.feature
@@ -1,0 +1,1 @@
+Add global option '--hide-token/--no-hide-token' to be used together with '--trace' for preventing the user's token from being printed to stderr for safety reasons.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Name | Description|
 |_\--network-timeout FLOAT_|Network read timeout, seconds.|
 |_--version_|Show the version and exit.|
 |_--trace_|Trace sent HTTP requests and received replies to stderr.|
-|_\--hide-token / --no-hide-token_|Prevent user's token sent in HTTP headers from being printed out to stderr during HTTP tracing. Can be used only together with option '--trace'.  \[default: True]|
+|_\--hide-token / --no-hide-token_|Prevent user's token sent in HTTP headers from being printed out to stderr during HTTP tracing. Can be used only together with option '--trace'  \[default: True]|
 |_--help_|Show this message and exit.|
 
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Name | Description|
 |_\--network-timeout FLOAT_|Network read timeout, seconds.|
 |_--version_|Show the version and exit.|
 |_--trace_|Trace sent HTTP requests and received replies to stderr.|
+|_\--hide-token / --no-hide-token_|Prevent user's token sent in HTTP headers from being printed out to stderr during HTTP tracing. Can be used only together with option '--trace'.|
 |_--help_|Show this message and exit.|
 
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Name | Description|
 |_\--network-timeout FLOAT_|Network read timeout, seconds.|
 |_--version_|Show the version and exit.|
 |_--trace_|Trace sent HTTP requests and received replies to stderr.|
-|_\--hide-token / --no-hide-token_|Prevent user's token sent in HTTP headers from being printed out to stderr during HTTP tracing. Can be used only together with option '--trace'  \[default: True]|
+|_\--hide-token / --no-hide-token_|Prevent user's token sent in HTTP headers from being printed out to stderr during HTTP tracing. Can be used only together with option '--trace'. On by default.|
 |_--help_|Show this message and exit.|
 
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Name | Description|
 |_\--network-timeout FLOAT_|Network read timeout, seconds.|
 |_--version_|Show the version and exit.|
 |_--trace_|Trace sent HTTP requests and received replies to stderr.|
-|_\--hide-token / --no-hide-token_|Prevent user's token sent in HTTP headers from being printed out to stderr during HTTP tracing. Can be used only together with option '--trace'.|
+|_\--hide-token / --no-hide-token_|Prevent user's token sent in HTTP headers from being printed out to stderr during HTTP tracing. Can be used only together with option '--trace'.  \[default: True]|
 |_--help_|Show this message and exit.|
 
 

--- a/neuromation/cli/main.py
+++ b/neuromation/cli/main.py
@@ -175,18 +175,18 @@ def print_options(
 )
 @click.option(
     "--trace",
+    default=None,
     is_flag=True,
     help="Trace sent HTTP requests and received replies to stderr.",
 )
 @click.option(
     "--hide-token/--no-hide-token",
     is_flag=True,
-    default=True,
-    show_default=True,
+    default=None,
     help=(
         "Prevent user's token sent in HTTP headers from being "
         "printed out to stderr during HTTP tracing. Can be used only "
-        "together with option '--trace'."
+        "together with option '--trace'  [default: True]"
     ),
 )
 @click.pass_context

--- a/neuromation/cli/main.py
+++ b/neuromation/cli/main.py
@@ -181,7 +181,8 @@ def print_options(
 @click.option(
     "--hide-token/--no-hide-token",
     is_flag=True,
-    default=None,
+    default=True,
+    show_default=True,
     help=(
         "Prevent user's token sent in HTTP headers from being "
         "printed out to stderr during HTTP tracing. Can be used only "

--- a/neuromation/cli/main.py
+++ b/neuromation/cli/main.py
@@ -185,7 +185,7 @@ def print_options(
     help=(
         "Prevent user's token sent in HTTP headers from being "
         "printed out to stderr during HTTP tracing. Can be used only "
-        "together with option '--trace'  [default: True]"
+        "together with option '--trace'. On by default."
     ),
 )
 @click.pass_context

--- a/neuromation/cli/main.py
+++ b/neuromation/cli/main.py
@@ -178,6 +178,16 @@ def print_options(
     is_flag=True,
     help="Trace sent HTTP requests and received replies to stderr.",
 )
+@click.option(
+    "--hide-token/--no-hide-token",
+    is_flag=True,
+    default=None,
+    help=(
+        "Prevent user's token sent in HTTP headers from being "
+        "printed out to stderr during HTTP tracing. Can be used only "
+        "together with option '--trace'."
+    ),
+)
 @click.pass_context
 def cli(
     ctx: click.Context,
@@ -189,6 +199,7 @@ def cli(
     disable_pypi_version_check: bool,
     network_timeout: float,
     trace: bool,
+    hide_token: Optional[bool],
 ) -> None:
     #   ▇ ◣
     #   ▇ ◥ ◣
@@ -211,6 +222,13 @@ def cli(
     ctx.color = real_color
     verbosity = verbose - quiet
     setup_logging(verbosity=verbosity, color=real_color)
+    if hide_token is None:
+        hide_token_bool = True
+    else:
+        if not trace:
+            option = "--hide-token" if hide_token else "--no-hide-token"
+            raise click.UsageError(f"{option} requires --trace")
+        hide_token_bool = hide_token
     root = Root(
         verbosity=verbosity,
         color=real_color,
@@ -220,6 +238,7 @@ def cli(
         network_timeout=network_timeout,
         config_path=Path(neuromation_config),
         trace=trace,
+        trace_hide_token=hide_token_bool,
     )
     ctx.obj = root
     if not ctx.invoked_subcommand:

--- a/neuromation/cli/main.py
+++ b/neuromation/cli/main.py
@@ -175,7 +175,6 @@ def print_options(
 )
 @click.option(
     "--trace",
-    default=None,
     is_flag=True,
     help="Trace sent HTTP requests and received replies to stderr.",
 )

--- a/neuromation/cli/root.py
+++ b/neuromation/cli/root.py
@@ -22,7 +22,7 @@ TEXT_TYPE = ("application/json", "text")
 
 HEADER_TOKEN_PATTERNS = [
     re.compile(rf"({auth_scheme})\s+([^ ]+\.[^ ]+\.[^ ]+)")
-    for auth_scheme in ("Bearer", "Basic")
+    for auth_scheme in ("Bearer", "Basic", "Digest", "Mutual")
 ]
 
 

--- a/neuromation/cli/root.py
+++ b/neuromation/cli/root.py
@@ -203,7 +203,9 @@ class Root:
         return text
 
     def _sanitize_token(self, token: str, tail_len: int = 5) -> str:
-        if not (0 < tail_len < len(token) // 2):
+        assert tail_len > 0, "invalid tail length"
+        # at least a third part of the token should be hidden
+        if tail_len >= len(token) // 3:
             return f"<hidden {len(token)} chars>"
 
         hidden = f"<hidden {len(token) - tail_len * 2} chars>"

--- a/neuromation/cli/root.py
+++ b/neuromation/cli/root.py
@@ -202,8 +202,8 @@ class Root:
             text = text.replace(token, token_safe)
         return text
 
-    def _sanitize_token(self, token: str, tail_len: int = 5) -> str:
-        assert tail_len > 0, "invalid tail length"
+    def _sanitize_token(self, token: str) -> str:
+        tail_len: int = 5
         # at least a third part of the token should be hidden
         if tail_len >= len(token) // 3:
             return f"<hidden {len(token)} chars>"

--- a/neuromation/cli/root.py
+++ b/neuromation/cli/root.py
@@ -203,9 +203,10 @@ class Root:
         return text
 
     def _sanitize_token(self, token: str, tail_len: int = 5) -> str:
-        assert 0 < tail_len, "tail too short"
-        assert tail_len < len(token) // 2, "tail too long"
-        hidden = f"<hidden {len(token) - tail_len*2} chars>"
+        if not (0 < tail_len < len(token) // 2):
+            return f"<hidden {len(token)} chars>"
+
+        hidden = f"<hidden {len(token) - tail_len * 2} chars>"
         return token[:tail_len] + hidden + token[-tail_len:]
 
     def _find_all_tokens(self, text: str) -> Iterator[str]:

--- a/neuromation/cli/root.py
+++ b/neuromation/cli/root.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from http.cookies import Morsel  # noqa
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, Iterator, List, Optional, Tuple
 
 import aiohttp
 import click
@@ -20,10 +20,9 @@ log = logging.getLogger(__name__)
 
 TEXT_TYPE = ("application/json", "text")
 
-HEADER_TOKEN_PATTERNS = [
-    re.compile(rf"({auth_scheme})\s+([^ ]+\.[^ ]+\.[^ ]+)")
-    for auth_scheme in ("Bearer", "Basic", "Digest", "Mutual")
-]
+HEADER_TOKEN_PATTERN = re.compile(
+    r"(Bearer|Basic|Digest|Mutual)\s+(?P<token>[^ ]+\.[^ ]+\.[^ ]+)"
+)
 
 
 @dataclass
@@ -36,6 +35,7 @@ class Root:
     config_path: Path
     trace: bool
     verbosity: int
+    trace_hide_token: bool = True
 
     _client: Optional[Client] = None
     _factory: Optional[Factory] = None
@@ -147,7 +147,9 @@ class Root:
             path += "?" + data.url.raw_query_string
         lines = [f"> {data.method} {path} HTTP/1.1"]
         for key, val in data.headers.items():
-            lines.append(f"> {key}: {self._sanitize_header_value(val)}")
+            if self.trace_hide_token:
+                val = self._sanitize_header_value(val)
+            lines.append(f"> {key}: {val}")
         lines.append("> ")
         self._print_debug(lines)
 
@@ -195,6 +197,17 @@ class Root:
         self._print_debug(lines)
 
     def _sanitize_header_value(self, text: str) -> str:
-        for pattern in HEADER_TOKEN_PATTERNS:
-            text = pattern.sub(r"\1 <token>", text)
+        for token in self._find_all_tokens(text):
+            token_safe = self._sanitize_token(token)
+            text = text.replace(token, token_safe)
         return text
+
+    def _sanitize_token(self, token: str, tail_len: int = 5) -> str:
+        assert 0 < tail_len, "tail too short"
+        assert tail_len < len(token) // 2, "tail too long"
+        hidden = f"<hidden {len(token) - tail_len*2} chars>"
+        return token[:tail_len] + hidden + token[-tail_len:]
+
+    def _find_all_tokens(self, text: str) -> Iterator[str]:
+        for match in HEADER_TOKEN_PATTERN.finditer(text):
+            yield match.group("token")

--- a/neuromation/cli/root.py
+++ b/neuromation/cli/root.py
@@ -207,7 +207,6 @@ class Root:
         # at least a third part of the token should be hidden
         if tail_len >= len(token) // 3:
             return f"<hidden {len(token)} chars>"
-
         hidden = f"<hidden {len(token) - tail_len * 2} chars>"
         return token[:tail_len] + hidden + token[-tail_len:]
 

--- a/tests/cli/test_root.py
+++ b/tests/cli/test_root.py
@@ -86,10 +86,19 @@ class TestTokenSanitization:
         line_safe = root_uninitialized._sanitize_header_value(line)
         assert line_safe == f"foo Authentication: {auth} not_a_jwt bar"
 
-    def test_sanitize_token_tail_too_short(self, root_uninitialized: Root) -> None:
-        token = "eyJhbGciOiJIUz.eyJzdWIjM0NTY3.SflKxwRJ_SsM"
-        with pytest.raises(AssertionError, match="tail too short"):
-            root_uninitialized._sanitize_token(token, tail_len=0)
+    @pytest.mark.parametrize(
+        "token,tail_len",
+        [
+            ("sec.ret.token", -1),
+            ("sec.ret.token", 0),
+            ("sec.ret.token", len("sec.ret.token") // 2 + 1),
+        ],
+    )
+    def test_sanitize_token_replaced_overall(
+        self, root_uninitialized: Root, token: str, tail_len: int
+    ) -> None:
+        line_safe = root_uninitialized._sanitize_token(token, tail_len)
+        assert line_safe == "<hidden 13 chars>"
 
     def test_sanitize_token_tail_too_long(self, root_uninitialized: Root) -> None:
         token = "eyJhbGciOiJIUz.eyJzdWIjM0NTY3.SflKxwRJ_SsM"

--- a/tests/cli/test_root.py
+++ b/tests/cli/test_root.py
@@ -50,3 +50,21 @@ def test_resource_presets_uninitialized(root_uninitialized: Root) -> None:
 
 def test_get_session_cookie(root_uninitialized: Root) -> None:
     assert root_uninitialized.get_session_cookie() is None
+
+
+def test_sanitize_header_value_bearer(root_uninitialized: Root) -> None:
+    text = "Bearer eyJhbGciOiJIUzI1N.eyJzdWIiOiIxMjM0NTY3.SflKxwRJ_SsMeKK"
+    clean = root_uninitialized._sanitize_header_value(text)
+    assert clean == "Bearer <token>"
+
+
+def test_sanitize_header_value_basic(root_uninitialized: Root) -> None:
+    text = "Basic eyJhbGciOiJIUzI1N.eyJzdWIiOiIxMjM0NTY3.SflKxwRJ_SsMeKK"
+    clean = root_uninitialized._sanitize_header_value(text)
+    assert clean == "Basic <token>"
+
+
+def test_sanitize_header_value_bearer_not_a_jwt(root_uninitialized: Root) -> None:
+    text = "Basic not_a_jwt"
+    clean = root_uninitialized._sanitize_header_value(text)
+    assert clean == "Basic not_a_jwt"

--- a/tests/cli/test_root.py
+++ b/tests/cli/test_root.py
@@ -99,8 +99,3 @@ class TestTokenSanitization:
     ) -> None:
         line_safe = root_uninitialized._sanitize_token(token, tail_len)
         assert line_safe == "<hidden 13 chars>"
-
-    def test_sanitize_token_tail_too_long(self, root_uninitialized: Root) -> None:
-        token = "eyJhbGciOiJIUz.eyJzdWIjM0NTY3.SflKxwRJ_SsM"
-        with pytest.raises(AssertionError, match="tail too long"):
-            root_uninitialized._sanitize_token(token, tail_len=len(token) // 2 + 1)

--- a/tests/cli/test_root.py
+++ b/tests/cli/test_root.py
@@ -52,19 +52,12 @@ def test_get_session_cookie(root_uninitialized: Root) -> None:
     assert root_uninitialized.get_session_cookie() is None
 
 
-def test_sanitize_header_value_bearer(root_uninitialized: Root) -> None:
-    text = "Bearer eyJhbGciOiJIUzI1N.eyJzdWIiOiIxMjM0NTY3.SflKxwRJ_SsMeKK"
-    clean = root_uninitialized._sanitize_header_value(text)
-    assert clean == "Bearer <token>"
+@pytest.mark.parametrize("auth_type", ["Bearer", "Basic", "Digest", "Mutual"])
+def test_sanitize_header_value(root_uninitialized: Root, auth_type: str) -> None:
+    with_token = f"{auth_type} eyJhbGciOiJIUzI1N.eyJzdWIiOiIxMjM0NTY3.SflKxwRJ_SsMeKK"
+    with_token_clean = root_uninitialized._sanitize_header_value(with_token)
+    assert with_token_clean == f"{auth_type} <token>"
 
-
-def test_sanitize_header_value_basic(root_uninitialized: Root) -> None:
-    text = "Basic eyJhbGciOiJIUzI1N.eyJzdWIiOiIxMjM0NTY3.SflKxwRJ_SsMeKK"
-    clean = root_uninitialized._sanitize_header_value(text)
-    assert clean == "Basic <token>"
-
-
-def test_sanitize_header_value_bearer_not_a_jwt(root_uninitialized: Root) -> None:
-    text = "Basic not_a_jwt"
-    clean = root_uninitialized._sanitize_header_value(text)
-    assert clean == "Basic not_a_jwt"
+    without_token = f"{auth_type} not_a_jwt"
+    without_token_clean = root_uninitialized._sanitize_header_value(without_token)
+    assert without_token_clean == f"{auth_type} not_a_jwt"

--- a/tests/cli/test_root.py
+++ b/tests/cli/test_root.py
@@ -91,8 +91,3 @@ class TestTokenSanitization:
         tail_len = len(token) // 3 + 1
         line_safe = root_uninitialized._sanitize_token(token, tail_len)
         assert line_safe == "<hidden 32 chars>"
-
-    def test_sanitize_token_invalid_tail_len(self, root_uninitialized: Root) -> None:
-        token = "eyJhbGcOiJI.eyJzdTY3.SfKxwRJ_SsM"
-        with pytest.raises(AssertionError, match="invalid tail length"):
-            root_uninitialized._sanitize_token(token, tail_len=0)

--- a/tests/cli/test_root.py
+++ b/tests/cli/test_root.py
@@ -87,7 +87,6 @@ class TestTokenSanitization:
         assert line_safe == f"{auth} not_a_jwt"
 
     def test_sanitize_token_replaced_overall(self, root_uninitialized: Root) -> None:
-        token = "eyJhbGcOiJI.eyJzdTY3.SfKxwRJ_SsM"
-        tail_len = len(token) // 3 + 1
-        line_safe = root_uninitialized._sanitize_token(token, tail_len)
-        assert line_safe == "<hidden 32 chars>"
+        token = "a.b.c"
+        line_safe = root_uninitialized._sanitize_token(token)
+        assert line_safe == "<hidden 5 chars>"

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -416,13 +416,11 @@ class Helper:
         try:
             proc.check_returncode()
         except subprocess.CalledProcessError:
-            log.error(f"Last return code: '{proc.returncode}'")
             log.error(f"Last stdout: '{proc.stdout}'")
             log.error(f"Last stderr: '{proc.stderr}'")
             raise
         out = proc.stdout
         err = proc.stderr
-        code = proc.returncode
         if any(
             start in " ".join(arguments)
             for start in ("submit", "job submit", "run", "job run")
@@ -433,7 +431,6 @@ class Helper:
         out = out.strip()
         err = err.strip()
         if verbosity > 0:
-            print(f"return code: {code}")
             print(f"nero stdout: {out}")
             print(f"nero stderr: {err}")
         return SysCap(out, err)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -74,7 +74,7 @@ def loop() -> Iterator[asyncio.AbstractEventLoop]:
     loop.close()
 
 
-SysCap = namedtuple("SysCap", "out err code")
+SysCap = namedtuple("SysCap", "out err")
 
 
 async def _run_async(
@@ -383,7 +383,6 @@ class Helper:
         arguments: List[str],
         *,
         verbosity: int = 0,
-        raise_for_returncode: bool = True,
         network_timeout: float = NETWORK_TIMEOUT,
     ) -> SysCap:
         __tracebackhide__ = True
@@ -414,14 +413,13 @@ class Helper:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
-        if raise_for_returncode:
-            try:
-                proc.check_returncode()
-            except subprocess.CalledProcessError:
-                log.error(f"Last return code: '{proc.returncode}'")
-                log.error(f"Last stdout: '{proc.stdout}'")
-                log.error(f"Last stderr: '{proc.stderr}'")
-                raise
+        try:
+            proc.check_returncode()
+        except subprocess.CalledProcessError:
+            log.error(f"Last return code: '{proc.returncode}'")
+            log.error(f"Last stdout: '{proc.stdout}'")
+            log.error(f"Last stderr: '{proc.stderr}'")
+            raise
         out = proc.stdout
         err = proc.stderr
         code = proc.returncode
@@ -438,7 +436,7 @@ class Helper:
             print(f"return code: {code}")
             print(f"nero stdout: {out}")
             print(f"nero stderr: {err}")
-        return SysCap(out, err, code)
+        return SysCap(out, err)
 
     @run_async
     async def run_job_and_wait_state(

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -40,33 +40,3 @@ def test_root_trace_hide_token_default_true(helper: Helper) -> None:
     assert "Authorization: Bearer " in captured.err
     assert "<hidden " in captured.err
     assert " chars>" in captured.err
-
-
-@pytest.mark.e2e
-def test_root_trace_hide_token_explicit_true(helper: Helper) -> None:
-    captured = helper.run_cli(["--trace", "--hide-token", "ls"])
-    assert "Authorization: Bearer " in captured.err
-    assert "<hidden " in captured.err
-    assert " chars>" in captured.err
-
-
-@pytest.mark.e2e
-def test_root_trace_hide_token_explicit_false(helper: Helper) -> None:
-    captured = helper.run_cli(["--trace", "--no-hide-token", "ls"])
-    assert "Authorization: Bearer " in captured.err
-    assert "<hidden " not in captured.err
-    assert " chars>" not in captured.err
-
-
-@pytest.mark.e2e
-def test_root_hide_token_true_without_trace_not_allowed(helper: Helper) -> None:
-    captured = helper.run_cli(["--hide-token", "ls"], raise_for_returncode=False)
-    assert captured.code == 2
-    assert "--hide-token requires --trace" in captured.err
-
-
-@pytest.mark.e2e
-def test_root_hide_token_false_without_trace_not_allowed(helper: Helper) -> None:
-    captured = helper.run_cli(["--no-hide-token", "ls"], raise_for_returncode=False)
-    assert captured.code == 2
-    assert "--no-hide-token requires --trace" in captured.err

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -32,3 +32,41 @@ def test_print_config_token(helper: Helper) -> None:
     captured = helper.run_cli(["config", "show-token"])
     assert not captured.err
     assert captured.out  # some secure information was printed
+
+
+@pytest.mark.e2e
+def test_root_trace_hide_token_default_true(helper: Helper) -> None:
+    captured = helper.run_cli(["--trace", "ls"])
+    assert "Authorization: Bearer " in captured.err
+    assert "<hidden " in captured.err
+    assert " chars>" in captured.err
+
+
+@pytest.mark.e2e
+def test_root_trace_hide_token_explicit_true(helper: Helper) -> None:
+    captured = helper.run_cli(["--trace", "--hide-token", "ls"])
+    assert "Authorization: Bearer " in captured.err
+    assert "<hidden " in captured.err
+    assert " chars>" in captured.err
+
+
+@pytest.mark.e2e
+def test_root_trace_hide_token_explicit_false(helper: Helper) -> None:
+    captured = helper.run_cli(["--trace", "--no-hide-token", "ls"])
+    assert "Authorization: Bearer " in captured.err
+    assert "<hidden " not in captured.err
+    assert " chars>" not in captured.err
+
+
+@pytest.mark.e2e
+def test_root_hide_token_true_without_trace_not_allowed(helper: Helper) -> None:
+    captured = helper.run_cli(["--hide-token", "ls"], raise_for_returncode=False)
+    assert captured.code == 2
+    assert "--hide-token requires --trace" in captured.err
+
+
+@pytest.mark.e2e
+def test_root_hide_token_false_without_trace_not_allowed(helper: Helper) -> None:
+    captured = helper.run_cli(["--no-hide-token", "ls"], raise_for_returncode=False)
+    assert captured.code == 2
+    assert "--no-hide-token requires --trace" in captured.err


### PR DESCRIPTION
Sorry for preparing the PR without an issue: I decided that this patch is small enough to avoid the bureaucracy.

Here's a small security issue: we need to hide user's sensitive data when printing out HTTP communication when `--trace` is enabled.

Thus, instead of 
```
$ neuro --trace run ubuntu
> GET /api/v1/config HTTP/1.1
> Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
> 
...
```
the user would get 
```
$ neuro --trace run ubuntu
> GET /api/v1/config HTTP/1.1
> Authorization: Bearer <token>
> 
...
```

Thus, when the user is asked to re-run a command with `--trace` and share it in a bug tracker, they can be sure their sensitive data won't be revealed.

Disclaimer: all tokens used in description are fake.