### PR TITLE
Better Docker api connection error handling

### DIFF
--- a/neuromation/api/images.py
+++ b/neuromation/api/images.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional, Set
 import aiodocker
 import aiohttp
 from aiodocker.exceptions import DockerError
+from aiohttp.client_exceptions import ClientConnectorError
 from yarl import URL
 
 from .abc import (
@@ -62,6 +63,22 @@ class Images(metaclass=NoPublicConstructor):
     def _auth(self) -> Dict[str, str]:
         return {"username": "token", "password": self._config.auth_token.token}
 
+    def _docker_connection_error(self, error: ClientConnectorError) -> None:
+        connector = self._docker.connector
+        if isinstance(connector, aiohttp.NamedPipeConnector) or isinstance(
+            connector, aiohttp.UnixConnector
+        ):
+            path = connector.path
+        else:
+            path = self._docker.docker_host
+        raise DockerError(
+            900,
+            {
+                "message": f"Cannot connect to Docker engine via {path}, "
+                f"{error.os_error.strerror}"
+            },
+        )
+
     async def push(
         self,
         local: LocalImage,
@@ -86,8 +103,11 @@ class Images(metaclass=NoPublicConstructor):
         except DockerError as error:
             if error.status == 404:
                 raise ValueError(
-                    f"Image {local} was not found " "in your local docker images"
+                    f"Image {local} was not found in your local docker images"
                 ) from error
+        except ClientConnectorError as error:
+            self._docker_connection_error(error)
+
         try:
             async for obj in self._docker.images.push(
                 repo, auth=self._auth(), stream=True
@@ -100,6 +120,9 @@ class Images(metaclass=NoPublicConstructor):
             if error.status == 403:
                 raise AuthorizationError(f"Access denied {remote}") from error
             raise  # pragma: no cover
+        except ClientConnectorError as error:
+            self._docker_connection_error(error)
+
         return remote
 
     async def pull(
@@ -138,6 +161,9 @@ class Images(metaclass=NoPublicConstructor):
             elif error.status == 403:
                 raise AuthorizationError(f"Access denied {remote}") from error
             raise  # pragma: no cover
+        except ClientConnectorError as error:
+            self._docker_connection_error(error)
+            raise
 
         await self._docker.images.tag(repo, local)
 


### PR DESCRIPTION
Alternative solution for  #897
Just show friendly message instead ping docker engine

On my system when docker service stopped unix socket still exists. And with this PR i see now:
> ERROR: Docker API error: Cannot connect to Docker engine via /run/docker.sock, Connection refused

it was before: 
>ERROR: Connection error (Cannot connect to host localhost:None ssl:default [Connection refused])

For remote host it will be:
>ERROR: Docker API error: Cannot connect to Docker engine via tcp://1.2.3.4:123, Connect call failed ('1.2.3.4', 123)

instead
>ERROR: Connection error (Cannot connect to host 1.2.3.4:123 ssl:default [Connect call failed ('1.2.3.4', 123)])