### PR TITLE
Trusted config path

### DIFF
--- a/CHANGELOG.D/1173.feature
+++ b/CHANGELOG.D/1173.feature
@@ -1,0 +1,1 @@
+Suppress security checks for config files if NEUROMATION_TRUSTED_CONFIG_PATH environment variable is on.

--- a/neuromation/api/__init__.py
+++ b/neuromation/api/__init__.py
@@ -23,6 +23,7 @@ from .config_factory import (
     CONFIG_ENV_NAME,
     DEFAULT_API_URL,
     DEFAULT_CONFIG_PATH,
+    TRUSTED_CONFIG_PATH,
     ConfigError,
     Factory,
 )
@@ -57,6 +58,7 @@ __all__ = (
     "DEFAULT_API_URL",
     "DEFAULT_CONFIG_PATH",
     "CONFIG_ENV_NAME",
+    "TRUSTED_CONFIG_PATH",
     "JobDescription",
     "JobStatus",
     "JobStatusHistory",

--- a/neuromation/cli/job.py
+++ b/neuromation/cli/job.py
@@ -15,6 +15,7 @@ from yarl import URL
 
 from neuromation.api import (
     CONFIG_ENV_NAME,
+    TRUSTED_CONFIG_PATH,
     AuthorizationError,
     Container,
     HTTPPort,
@@ -881,6 +882,7 @@ async def run_job(
             )
         env_var, secret_volume = await upload_and_map_config(root)
         env_dict[CONFIG_ENV_NAME] = env_var
+        env_dict[TRUSTED_CONFIG_PATH] = "1"
         volumes.add(secret_volume)
 
     if volumes:

--- a/tests/api/test_config_factory.py
+++ b/tests/api/test_config_factory.py
@@ -13,7 +13,7 @@ from yarl import URL
 
 import neuromation
 import neuromation.api.config_factory
-from neuromation.api import ConfigError, Factory
+from neuromation.api import ConfigError, Factory, TRUSTED_CONFIG_PATH
 from neuromation.api.config import (
     _AuthConfig,
     _AuthToken,
@@ -230,13 +230,15 @@ class TestConfigFileInteraction:
         sys.platform == "win32",
         reason="Windows does not supports UNIX-like permissions",
     )
-    async def test_file_permissions_not_in_home_folder(
+    async def test_file_permissions_suppress_security_check(
         self,
         tmpdir: Path,
         token: str,
         auth_config: _AuthConfig,
         cluster_config: _ClusterConfig,
+        monkeypatch: Any,
     ) -> None:
+        monkeypatch.setenv(TRUSTED_CONFIG_PATH, "1")
         config_path = Path(tmpdir) / "test.nmrc"
         _create_config(config_path, token, auth_config, cluster_config)
         config_path.chmod(0o644)

--- a/tests/api/test_config_factory.py
+++ b/tests/api/test_config_factory.py
@@ -13,7 +13,7 @@ from yarl import URL
 
 import neuromation
 import neuromation.api.config_factory
-from neuromation.api import ConfigError, Factory, TRUSTED_CONFIG_PATH
+from neuromation.api import TRUSTED_CONFIG_PATH, ConfigError, Factory
 from neuromation.api.config import (
     _AuthConfig,
     _AuthToken,


### PR DESCRIPTION
Provided by explicit `NEUROMATION_TRUSTED_CONFIG_PATH=1` environment variable