### PR TITLE
shlex-quote executed command if the command is multi-part

### DIFF
--- a/CHANGELOG.D/1229.bugfix
+++ b/CHANGELOG.D/1229.bugfix
@@ -1,0 +1,1 @@
+Correctly process both quoted command arguments (`neuro run python:latest "python3 -c 'import os'") as well as unquoted version (`neuro run python:latest python3 -c 'import os'`).

--- a/neuromation/cli/job.py
+++ b/neuromation/cli/job.py
@@ -853,7 +853,13 @@ async def run_job(
 
     env_dict = build_env(env, env_file)
 
-    cmd = " ".join(cmd) if cmd is not None else None
+    if cmd is None:
+        real_cmd: Optional[str] = None
+    elif len(cmd) == 1:
+        real_cmd = cmd[0]
+    else:
+        real_cmd = " ".join(shlex.quote(arg) for arg in cmd)
+
     log.debug(f'entrypoint="{entrypoint}"')
     log.debug(f'cmd="{cmd}"')
 
@@ -894,7 +900,7 @@ async def run_job(
     container = Container(
         image=image,
         entrypoint=entrypoint,
-        command=cmd,
+        command=real_cmd,
         http=HTTPPort(http, http_auth) if http else None,
         resources=resources,
         env=env_dict,

--- a/tests/e2e/test_e2e_jobs.py
+++ b/tests/e2e/test_e2e_jobs.py
@@ -51,7 +51,6 @@ def test_job_submit(helper: Helper) -> None:
     store_out_list = captured.out.split("\n")[1:]
     jobs_orig = [x.split("  ")[0] for x in store_out_list]
 
-    command = 'bash -c "sleep 10m; false"'
     captured = helper.run_cli(
         [
             "job",
@@ -64,7 +63,10 @@ def test_job_submit(helper: Helper) -> None:
             "--name",
             job_name,
             UBUNTU_IMAGE_NAME,
-            command,
+            # use unrolled notation to check shlex.join()
+            "bash",
+            "-c",
+            "sleep 10m; false",
         ]
     )
     match = re.match("Job ID: (.+) Status:", captured.out)
@@ -91,7 +93,7 @@ def test_job_submit(helper: Helper) -> None:
     store_out = captured.out
     assert job_id in store_out
     # Check that the command is in the list
-    assert command in store_out
+    assert "bash -c 'sleep 10m; false'" in store_out
 
 
 @pytest.mark.e2e
@@ -104,7 +106,7 @@ def test_job_description(helper: Helper) -> None:
     jobs_orig = [x.split("  ")[0] for x in store_out_list]
     description = "Test description for a job"
     # Run a new job
-    command = 'bash -c "sleep 10m; false"'
+    command = "bash -c 'sleep 10m; false'"
     captured = helper.run_cli(
         [
             "job",


### PR DESCRIPTION
Fix #1229

The idea is: quote multi-args command, pass the single-arg command as is.