### PR TITLE
Fix styling in tables

### DIFF
--- a/neuromation/cli/formatters/admin.py
+++ b/neuromation/cli/formatters/admin.py
@@ -4,18 +4,25 @@ import click
 
 from neuromation.api.admin import _Cluster, _ClusterUser
 
-from .ftable import table
+from .ftable import ColumnWidth, table
 
 
 class ClusterUserFormatter:
     def __call__(self, clusters_users: Iterable[_ClusterUser]) -> List[str]:
-        headers = (click.style("Name", bold=True), click.style("Role", bold=True))
+        headers = (
+            click.style(
+                "Name is super long oh my god what to do ", bold=True, reset=False
+            )
+            + click.style("underlined", underline=True)
+            + " partialy styled",
+            click.style("Role", bold=True),
+        )
         rows = [headers]
 
         for user in clusters_users:
             rows.append((user.user_name, user.role.value))
 
-        return list(table(rows=rows))
+        return list(table(rows=rows, widths=[ColumnWidth(max=20)] * 2))
 
 
 class ClustersFormatter:

--- a/neuromation/cli/formatters/admin.py
+++ b/neuromation/cli/formatters/admin.py
@@ -9,8 +9,9 @@ from .ftable import table
 
 class ClusterUserFormatter:
     def __call__(self, clusters_users: Iterable[_ClusterUser]) -> List[str]:
-        headers = ("Name", "Role")
+        headers = (click.style("Name", bold=True), click.style("Role", bold=True))
         rows = [headers]
+
         for user in clusters_users:
             rows.append((user.user_name, user.role.value))
 

--- a/neuromation/cli/formatters/admin.py
+++ b/neuromation/cli/formatters/admin.py
@@ -4,25 +4,18 @@ import click
 
 from neuromation.api.admin import _Cluster, _ClusterUser
 
-from .ftable import ColumnWidth, table
+from .ftable import table
 
 
 class ClusterUserFormatter:
     def __call__(self, clusters_users: Iterable[_ClusterUser]) -> List[str]:
-        headers = (
-            click.style(
-                "Name is super long oh my god what to do ", bold=True, reset=False
-            )
-            + click.style("underlined", underline=True)
-            + " partialy styled",
-            click.style("Role", bold=True),
-        )
+        headers = (click.style("Name", bold=True), click.style("Role", bold=True))
         rows = [headers]
 
         for user in clusters_users:
             rows.append((user.user_name, user.role.value))
 
-        return list(table(rows=rows, widths=[ColumnWidth(max=20)] * 2))
+        return list(table(rows=rows))
 
 
 class ClustersFormatter:

--- a/neuromation/cli/formatters/ftable.py
+++ b/neuromation/cli/formatters/ftable.py
@@ -105,7 +105,10 @@ def _row(
             cell or "".ljust(width or 0) for cell, width in zip_longest(cells, widths)
         )
         if max_width:
-            yield line[:max_width]
+            line = line[:max_width]
+            if "\033" in line:
+                line += ansi_reset_all
+            yield line
         else:
             yield line
 

--- a/neuromation/cli/utils.py
+++ b/neuromation/cli/utils.py
@@ -785,7 +785,6 @@ class StyledTextHelper:
 
         result: List[str] = []
 
-        print(repr(text), repr(wrapped), sm.get_opcodes())
         for op, ti, tj, wi, wj in sm.get_opcodes():
             if op == "equal" or op == "insert":
                 # For those 2 cases we just take the text wrap() generated for us

--- a/neuromation/cli/utils.py
+++ b/neuromation/cli/utils.py
@@ -754,7 +754,6 @@ class StyledTextHelper:
             else:
                 if len(token) >= remaining:
                     result.append(token[:remaining])
-                    remaining = 0
                     break
                 remaining -= len(token)
                 result.append(token)

--- a/neuromation/cli/utils.py
+++ b/neuromation/cli/utils.py
@@ -10,7 +10,7 @@ from contextlib import suppress
 from datetime import date, timedelta
 from difflib import SequenceMatcher
 from functools import lru_cache, wraps
-from textwrap import wrap, fill
+from textwrap import fill, wrap
 from typing import (
     Any,
     Awaitable,

--- a/neuromation/cli/utils.py
+++ b/neuromation/cli/utils.py
@@ -9,7 +9,7 @@ import time
 from contextlib import suppress
 from datetime import date, timedelta
 from difflib import SequenceMatcher
-from functools import lru_cache, wraps
+from functools import wraps
 from textwrap import fill, wrap
 from typing import (
     Any,
@@ -704,12 +704,10 @@ class StyledTextHelper:
     # As we often do operations on headers or similar static text it makes sense to
     # cache
     @classmethod
-    @lru_cache(255)
     def unstyle(cls, text: str) -> str:
         return click.unstyle(text)
 
     @classmethod
-    @lru_cache(255)
     def width(cls, text: str) -> int:
         if cls.is_styled(text):
             return wcswidth(cls.unstyle(text))

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts= --cov-branch --cov-report xml
+addopts= --cov-branch --cov-report xml -p no:asyncio
 log_cli=false
 log_level=INFO
 junit_family=xunit2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,4 +14,5 @@ humanize==0.5.1
 certifi==2019.11.28
 psutil==5.6.7
 typing_extensions==3.7.4.1
+wcwidth==0.1.7
 -e .

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,3 +56,7 @@ ignore_missing_imports = true
 
 [mypy-idna]
 ignore_missing_imports = true
+
+[mypy-wcwidth]
+ignore_missing_imports = true
+

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         "certifi",
         "cookiecutter==1.6.0",
         "atomicwrites>=1.0",
+        "wcwidth==0.1.7",
     ],
     include_package_data=True,
     description="Neuro Platform API client",

--- a/tests/cli/test_formatters.py
+++ b/tests/cli/test_formatters.py
@@ -1874,7 +1874,7 @@ class TestClusterUserFormatter:
             _ClusterUser(user_name="alex", role=_ClusterUserRoleType("user")),
         ]
         expected_out = [
-            "Name    Role   ",
+            "\x1b[1mName\x1b[0m    \x1b[1mRole\x1b[0m   ",
             "denis   admin  ",
             "andrew  manager",
             "ivan    user   ",

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -686,7 +686,7 @@ class TestStyledTextHelper:
             ("Simple text", 100, ["Simple text"]),
             ("Simple text", 6, ["Simple", "text"]),
             ("Simple text", 4, ["Simp", "le", "text"]),
-            # # Styled cases
+            # Styled cases
             (
                 click.style("Harder ", bold=True) + "text",
                 100,
@@ -705,7 +705,7 @@ class TestStyledTextHelper:
             (
                 click.style("Very ", underline=True, reset=False)
                 + click.style("Hard", bold=True)
-                + "text",
+                + " text",
                 4,
                 [
                     click.style("Very", underline=True),

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -11,12 +11,12 @@ from neuromation.api import Action, Client
 from neuromation.cli.root import Root
 from neuromation.cli.utils import (
     LocalRemotePortParamType,
+    StyledTextHelper,
     pager_maybe,
     parse_file_resource,
     parse_permission_action,
     parse_resource_for_sharing,
     resolve_job,
-    StyledTextHelper,
 )
 from tests import _TestServerFactory
 


### PR DESCRIPTION
Fixes #1245 

@asvetlov @serhiy-storchaka Hey guys, I did not yet do tests for this but want your opinion if we want this type of a fix. The aim was to support any styling in the table although extracting it from a string seems a bit ugly...

Alternatively, we could do something very simple instead, like:
```python
table(..., header_style="bold")
```
Or add a class StyledCell that can wrap cell text and provide style information explicitly.
```python
headers = (StyledCell("Name", bold=True), StyledCell("Role", bold=True))
table(rows=[headers] + other_rows)
```