### PR TITLE
`neuro kill` exits now non-zero code if it failed to kill any job in the list

### DIFF
--- a/CHANGELOG.D/1272.bug
+++ b/CHANGELOG.D/1272.bug
@@ -1,0 +1,1 @@
+`neuro kill` exits now non-zero code if it failed to kill any job in the list.

--- a/neuromation/cli/job.py
+++ b/neuromation/cli/job.py
@@ -609,7 +609,9 @@ async def kill(root: Root, jobs: Sequence[str]) -> None:
         return click.style(f"Cannot kill job {job}: {reason}", fg="red")
 
     for job, error in errors:
-        click.echo(format_fail(job, error))
+        click.echo(format_fail(job, error), err=True)
+    if errors:
+        sys.exit(1)
 
 
 @command(context_settings=dict(allow_interspersed_args=False))

--- a/tests/e2e/test_e2e_jobs.py
+++ b/tests/e2e/test_e2e_jobs.py
@@ -160,11 +160,14 @@ def test_job_description(helper: Helper) -> None:
 @pytest.mark.e2e
 def test_job_kill_non_existing(helper: Helper) -> None:
     # try to kill non existing job
-    phantom_id = "NOT_A_JOB_ID"
+    phantom_id = "not-a-job-id"
     expected_out = f"Cannot kill job {phantom_id}"
-    captured = helper.run_cli(["job", "kill", phantom_id])
-    killed_jobs = [x.strip() for x in captured.out.split("\n")]
-    assert len(killed_jobs) == 1
+    with pytest.raises(subprocess.CalledProcessError) as cm:
+        helper.run_cli(["job", "kill", phantom_id])
+    assert cm.value.returncode == 1
+    assert cm.value.stdout == ''
+    killed_jobs = cm.value.stderr.splitlines()
+    assert len(killed_jobs) == 1, killed_jobs
     assert killed_jobs[0].startswith(expected_out)
 
 

--- a/tests/e2e/test_e2e_jobs.py
+++ b/tests/e2e/test_e2e_jobs.py
@@ -165,7 +165,7 @@ def test_job_kill_non_existing(helper: Helper) -> None:
     with pytest.raises(subprocess.CalledProcessError) as cm:
         helper.run_cli(["job", "kill", phantom_id])
     assert cm.value.returncode == 1
-    assert cm.value.stdout == ''
+    assert cm.value.stdout == ""
     killed_jobs = cm.value.stderr.splitlines()
     assert len(killed_jobs) == 1, killed_jobs
     assert killed_jobs[0].startswith(expected_out)


### PR DESCRIPTION
Error messages are output now to stderr instead of stdout.

Fixes #1272.