### PR TITLE
Allow blank lines and comments in --env-file.

### DIFF
--- a/CHANGELOG.D/1208.feature
+++ b/CHANGELOG.D/1208.feature
@@ -1,0 +1,1 @@
+`--env-file` now allows blank lines and comments (lines starting with "#") in the file.

--- a/neuromation/cli/job.py
+++ b/neuromation/cli/job.py
@@ -7,7 +7,7 @@ import sys
 import textwrap
 import uuid
 import webbrowser
-from typing import Dict, List, Optional, Sequence, Set, Tuple
+from typing import Dict, Iterator, List, Optional, Sequence, Set, Tuple
 
 import async_timeout
 import click
@@ -80,10 +80,18 @@ def _get_neuro_mountpoint(username: str) -> str:
     return f"{ROOT_MOUNTPOINT}/{username}"
 
 
+def _read_lines(env_file: str) -> Iterator[str]:
+    with open(env_file, "r") as ef:
+        lines = ef.read().splitlines()
+    for line in lines:
+        line = line.lstrip()
+        if line and not line.startswith("#"):
+            yield line
+
+
 def build_env(env: Sequence[str], env_file: Optional[str]) -> Dict[str, str]:
     if env_file:
-        with open(env_file, "r") as ef:
-            env = ef.read().splitlines() + list(env)
+        env = [*_read_lines(env_file), *env]
 
     env_dict = {}
     for line in env:

--- a/tests/cli/test_job.py
+++ b/tests/cli/test_job.py
@@ -138,6 +138,24 @@ def test_build_env_reserved_env_var_conflict_passed_in_file(
         build_env(env_1, env_file=str(env_file))
 
 
+def test_build_env_blank_lines(tmp_path: Path) -> None:
+    env_file = tmp_path / "env_var.txt"
+    env_file.write_text("ENV_VAR_1=value1\n\n  \n\t\nENV_VAR_2=value2")
+    assert build_env([], env_file=str(env_file)) == {
+        "ENV_VAR_1": "value1",
+        "ENV_VAR_2": "value2",
+    }
+
+
+def test_build_env_comments(tmp_path: Path) -> None:
+    env_file = tmp_path / "env_var.txt"
+    env_file.write_text("ENV_VAR_1=value1\n#ENV_VAR_2=value2\nENV_VAR_3=#value3#")
+    assert build_env([], env_file=str(env_file)) == {
+        "ENV_VAR_1": "value1",
+        "ENV_VAR_3": "#value3#",
+    }
+
+
 async def test_calc_columns_section_doesnt_exist(
     monkeypatch: Any, tmp_path: Path, make_client: _MakeClient
 ) -> None:


### PR DESCRIPTION
Closes #1208.