### PR TITLE
Use explicit encoding for text files.

### DIFF
--- a/neuromation/cli/admin.py
+++ b/neuromation/cli/admin.py
@@ -75,7 +75,7 @@ async def generate_cluster_config(root: Root, config: str, type: str) -> None:
         content = await generate_gcp()
     else:
         assert False, "Prompt should prevent this case"
-    config_path.write_text(content)
+    config_path.write_text(content, encoding="utf-8")
     if not root.quiet:
         click.echo(f"Cluster config {config_path} is generated.")
 
@@ -163,7 +163,7 @@ async def generate_gcp() -> str:
         "Service Account Key File (.json)",
         default=os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"),
     )
-    with open(credentials_file) as fp:
+    with open(credentials_file, "rb") as fp:
         data = json.load(fp)
     out = yaml.dump(data)
     args["credentials"] = "\n" + "\n".join("  " + line for line in out.splitlines())

--- a/neuromation/cli/completion.py
+++ b/neuromation/cli/completion.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from pathlib import Path
 
@@ -36,8 +37,11 @@ def patch(shell: str) -> None:
     Automatically patch shell configuration profile to enable completion
     """
     profile_file = CFG_FILE[shell].expanduser()
-    with profile_file.open("a+") as profile:
+    with profile_file.open("ab+") as profile:
         profile.write(
-            ACTIVATION_TEMPLATE.format(cmd=SOURCE_CMD[shell], exe=sys.argv[0])
+            b"\n"
+            + os.fsencode(
+                ACTIVATION_TEMPLATE.format(cmd=SOURCE_CMD[shell], exe=sys.argv[0])
+            )
+            + b"\n"
         )
-        profile.write("\n")

--- a/neuromation/cli/config.py
+++ b/neuromation/cli/config.py
@@ -204,15 +204,15 @@ async def docker(root: Root, docker_config: str) -> None:
     json_path = config_path / "config.json"
     payload: Dict[str, Any] = {}
     if json_path.exists():
-        with json_path.open("r") as file:
+        with json_path.open("rb") as file:
             payload = json.load(file)
     if "credHelpers" not in payload:
         payload["credHelpers"] = {}
 
     registry = URL(root.client.config.registry_url).host
     payload["credHelpers"][registry] = "neuro"
-    with json_path.open("w") as file:
-        json.dump(payload, file, indent=2)
+    with json_path.open("w", encoding="utf-8") as file2:
+        json.dump(payload, file2, indent=2)
 
     json_path_str = f"{json_path}"
     registry_str = click.style(f"{registry}", bold=True)

--- a/neuromation/cli/job.py
+++ b/neuromation/cli/job.py
@@ -82,7 +82,7 @@ def _get_neuro_mountpoint(username: str) -> str:
 
 def build_env(env: Sequence[str], env_file: Optional[str]) -> Dict[str, str]:
     if env_file:
-        with open(env_file, "r") as ef:
+        with open(env_file, encoding="utf-8-sig") as ef:
             env = ef.read().splitlines() + list(env)
 
     env_dict = {}

--- a/tests/api/test_config_factory.py
+++ b/tests/api/test_config_factory.py
@@ -263,14 +263,14 @@ class TestConfigFileInteraction:
     async def test_mailformed_config(self, config_dir: Path) -> None:
         # await Factory().login(url=mock_for_login)
         config_file = config_dir / "db"
-        with config_file.open("r") as f:
+        with config_file.open("rb") as f:
             original = yaml.safe_load(f)
 
         for key in ["auth_config", "auth_token", "pypi", "clusters", "url"]:
             modified = original.copy()
             del modified[key]
-            with config_file.open("w") as f:
-                yaml.safe_dump(modified, f, default_flow_style=False)
+            with config_file.open("w", encoding="utf-8") as f2:
+                yaml.safe_dump(modified, f2, default_flow_style=False)
             with pytest.raises(ConfigError, match=r"Malformed"):
                 await Factory().get()
 
@@ -288,16 +288,16 @@ class TestConfigFileInteraction:
             show_dummy_browser, url=mock_for_login.make_url("/")
         )
         config_file = config_dir / "db"
-        with config_file.open("r") as f:
+        with config_file.open("rb") as f:
             config = yaml.safe_load(f)
         config["version"] = "10.1.1"  # config belongs old version
         config["url"] = str(mock_for_login.make_url("/"))
-        with config_file.open("w") as f:
-            yaml.safe_dump(config, f)
+        with config_file.open("w", encoding="utf-8") as f2:
+            yaml.safe_dump(config, f2)
         client = await Factory(config_dir).get()
         await client.close()
 
-        with config_file.open("r") as f:
+        with config_file.open("rb") as f:
             config = yaml.safe_load(f)
         assert config["version"] == neuromation.__version__
 
@@ -306,12 +306,12 @@ class TestConfigFileInteraction:
     ) -> None:
         # await Factory().login(url=mock_for_login)
         config_file = config_dir / "db"
-        with config_file.open("r") as f:
+        with config_file.open("rb") as f:
             config = yaml.safe_load(f)
         config["version"] = "10.1.1"  # config belongs old version
         config["url"] = str(mock_for_login.make_url("/"))
-        with config_file.open("w") as f:
-            yaml.safe_dump(config, f)
+        with config_file.open("w", encoding="utf-8") as f2:
+            yaml.safe_dump(config, f2)
         with pytest.raises(ConfigError, match="Neuro Platform CLI updated"):
             await Factory(config_dir).get()
 

--- a/tests/cli/test_docker_helper.py
+++ b/tests/cli/test_docker_helper.py
@@ -75,7 +75,7 @@ class TestCli:
         capture = run_cli(["config", "docker"])
         assert not capture.err
         assert json_path.is_file()
-        with json_path.open() as fp:
+        with json_path.open("rb") as fp:
             payload = json.load(fp)
         registry = URL(config.clusters[config.cluster_name].registry_url).host
         assert payload["credHelpers"] == {registry: "neuro"}
@@ -86,7 +86,7 @@ class TestCli:
         capture = run_cli(["config", "docker", "--docker-config", str(path)])
         assert not capture.err
         assert json_path.is_file()
-        with json_path.open() as fp:
+        with json_path.open("rb") as fp:
             payload = json.load(fp)
         registry = URL(config.clusters[config.cluster_name].registry_url).host
         assert payload["credHelpers"] == {registry: "neuro"}
@@ -97,16 +97,16 @@ class TestCli:
         path = tmp_path / ".docker"
         path.mkdir()
         json_path = path / "config.json"
-        with json_path.open("w") as fp:
-            json.dump({"test": "value"}, fp)
+        with json_path.open("w", encoding="utf-8") as fp:
+            json.dump({"test": "value\u20ac"}, fp)
         capture = run_cli(["config", "docker", "--docker-config", str(path)])
         assert not capture.err
         assert json_path.is_file()
-        with json_path.open() as fp:
-            payload = json.load(fp)
+        with json_path.open("rb") as fp2:
+            payload = json.load(fp2)
         registry = URL(config.clusters[config.cluster_name].registry_url).host
         assert payload["credHelpers"] == {registry: "neuro"}
-        assert payload["test"] == "value"
+        assert payload["test"] == "value\u20ac"
 
     def test_merge_file_with_existing_helpers(
         self, run_cli: _RunCli, tmp_path: Path, config: _Config
@@ -114,16 +114,18 @@ class TestCli:
         path = tmp_path / ".docker"
         path.mkdir()
         json_path = path / "config.json"
-        with json_path.open("w") as fp:
-            json.dump({"test": "value", "credHelpers": {"some.com": "handler"}}, fp)
+        with json_path.open("w", encoding="utf-8") as fp:
+            json.dump(
+                {"test": "value\u20ac", "credHelpers": {"some.com": "handler"}}, fp
+            )
         capture = run_cli(["config", "docker", "--docker-config", str(path)])
         assert not capture.err
         assert json_path.is_file()
-        with json_path.open() as fp:
-            payload = json.load(fp)
+        with json_path.open("rb") as fp2:
+            payload = json.load(fp2)
         registry = URL(config.clusters[config.cluster_name].registry_url).host
         assert payload["credHelpers"] == {registry: "neuro", "some.com": "handler"}
-        assert payload["test"] == "value"
+        assert payload["test"] == "value\u20ac"
 
     def test_success_output_message(
         self, run_cli: _RunCli, tmp_path: Path, config: _Config


### PR DESCRIPTION
* JSON and YAML files are written with explicit UTF-8 encoding.
* JSON and YAML are read from binary files. `json.load()` and `yaml.safe_load()` automatically decode UTF-8, support BOM and UTF-16.
* Filesystem encoding is used for ".bashrc" and ".zshrc".

Closes #1297.