### PR TITLE
Support hidden files on the storage

### DIFF
--- a/CHANGELOG.D/1362.feature
+++ b/CHANGELOG.D/1362.feature
@@ -1,0 +1,1 @@
+Support hidden files on the storage. Hide names started with a dot by default, provide ``neuro ls --all`` option to show all files.

--- a/README.md
+++ b/README.md
@@ -894,10 +894,11 @@ neuro storage ls [OPTIONS] [PATHS]...
 
 Name | Description|
 |----|------------|
-|_\-h, --human-readable_|with -l print human readable sizes \(e.g., 2K, 540M)|
-|_-l_|use a long listing format|
-|_--sort \[name &#124; size &#124; time]_|sort by given field, default is name|
-|_\-d, --directory_|list directories themselves, not their contents|
+|_\-h, --human-readable_|with -l print human readable sizes \(e.g., 2K, 540M).|
+|_-l_|use a long listing format.|
+|_--sort \[name &#124; size &#124; time]_|sort by given field, default is name.|
+|_\-d, --directory_|list directories themselves, not their contents.|
+|_\-a, --all_|do not ignore entries starting with .|
 |_--help_|Show this message and exit.|
 
 
@@ -2064,10 +2065,11 @@ neuro ls [OPTIONS] [PATHS]...
 
 Name | Description|
 |----|------------|
-|_\-h, --human-readable_|with -l print human readable sizes \(e.g., 2K, 540M)|
-|_-l_|use a long listing format|
-|_--sort \[name &#124; size &#124; time]_|sort by given field, default is name|
-|_\-d, --directory_|list directories themselves, not their contents|
+|_\-h, --human-readable_|with -l print human readable sizes \(e.g., 2K, 540M).|
+|_-l_|use a long listing format.|
+|_--sort \[name &#124; size &#124; time]_|sort by given field, default is name.|
+|_\-d, --directory_|list directories themselves, not their contents.|
+|_\-a, --all_|do not ignore entries starting with .|
 |_--help_|Show this message and exit.|
 
 

--- a/neuromation/cli/storage.py
+++ b/neuromation/cli/storage.py
@@ -173,7 +173,8 @@ async def ls(
                 else:
                     formatter = SimpleFilesFormatter(root.color)
 
-            files = [item for item in files if not item.name.startswith(".")]
+            if not show_all:
+                files = [item for item in files if not item.name.startswith(".")]
             pager_maybe(formatter(files), root.tty, root.terminal_size)
 
     if errors:

--- a/neuromation/cli/storage.py
+++ b/neuromation/cli/storage.py
@@ -104,20 +104,27 @@ async def rm(root: Root, paths: Sequence[str], recursive: bool, glob: bool) -> N
     "--human-readable",
     "-h",
     is_flag=True,
-    help="with -l print human readable sizes (e.g., 2K, 540M)",
+    help="with -l print human readable sizes (e.g., 2K, 540M).",
 )
-@option("-l", "format_long", is_flag=True, help="use a long listing format")
+@option("-l", "format_long", is_flag=True, help="use a long listing format.")
 @option(
     "--sort",
     type=click.Choice(["name", "size", "time"]),
     default="name",
-    help="sort by given field, default is name",
+    help="sort by given field, default is name.",
 )
 @option(
     "-d",
     "--directory",
     is_flag=True,
-    help="list directories themselves, not their contents",
+    help="list directories themselves, not their contents.",
+)
+@option(
+    "-a",
+    "--all",
+    "show_all",
+    is_flag=True,
+    help="do not ignore entries starting with .",
 )
 async def ls(
     root: Root,
@@ -126,6 +133,7 @@ async def ls(
     format_long: bool,
     sort: str,
     directory: bool,
+    show_all: bool,
 ) -> None:
     """
     List directory contents.
@@ -165,6 +173,7 @@ async def ls(
                 else:
                     formatter = SimpleFilesFormatter(root.color)
 
+            files = [item for item in files if not item.name.startswith(".")]
             pager_maybe(formatter(files), root.tty, root.terminal_size)
 
     if errors:

--- a/tests/e2e/test_e2e_storage.py
+++ b/tests/e2e/test_e2e_storage.py
@@ -635,22 +635,10 @@ def test_e2e_ls_skip_hidden(tmp_path: Path, helper: Helper) -> None:
     (folder / ".bar").write_bytes(b"bar")
 
     helper.run_cli(
-        [
-            "storage",
-            "cp",
-            "-r",
-            tmp_path.as_uri() + "/folder",
-            helper.tmpstorage
-        ]
+        ["storage", "cp", "-r", tmp_path.as_uri() + "/folder", helper.tmpstorage]
     )
 
-    captured = helper.run_cli(
-        [
-            "storage",
-            "ls",
-            helper.tmpstorage + "/folder"
-        ]
-    )
+    captured = helper.run_cli(["storage", "ls", helper.tmpstorage + "/folder"])
     assert captured.out.splitlines() == ["foo"]
 
 
@@ -664,21 +652,8 @@ def test_e2e_ls_show_hidden(tmp_path: Path, helper: Helper) -> None:
     (folder / ".bar").write_bytes(b"bar")
 
     helper.run_cli(
-        [
-            "storage",
-            "cp",
-            "-r",
-            tmp_path.as_uri() + "/folder",
-            helper.tmpstorage
-        ]
+        ["storage", "cp", "-r", tmp_path.as_uri() + "/folder", helper.tmpstorage]
     )
 
-    captured = helper.run_cli(
-        [
-            "storage",
-            "ls",
-            "--all",
-            helper.tmpstorage + "/folder"
-        ]
-    )
-    assert captured.out.splitlines() == ["foo"]
+    captured = helper.run_cli(["storage", "ls", "--all", helper.tmpstorage + "/folder"])
+    assert captured.out.splitlines() == [".bar", "foo"]

--- a/tests/e2e/test_e2e_storage.py
+++ b/tests/e2e/test_e2e_storage.py
@@ -623,3 +623,62 @@ def test_e2e_cp_filter(tmp_path: Path, helper: Helper) -> None:
         ]
     )
     assert os.listdir(tmp_path / "filtered") == ["bar"]
+
+
+@pytest.mark.e2e
+def test_e2e_ls_skip_hidden(tmp_path: Path, helper: Helper) -> None:
+    # Create files and directories and copy them to storage
+    helper.mkdir("")
+    folder = tmp_path / "folder"
+    folder.mkdir()
+    (folder / "foo").write_bytes(b"foo")
+    (folder / ".bar").write_bytes(b"bar")
+
+    helper.run_cli(
+        [
+            "storage",
+            "cp",
+            "-r",
+            tmp_path.as_uri() + "/folder",
+            helper.tmpstorage
+        ]
+    )
+
+    captured = helper.run_cli(
+        [
+            "storage",
+            "ls",
+            helper.tmpstorage + "/folder"
+        ]
+    )
+    assert captured.out.splitlines() == ["foo"]
+
+
+@pytest.mark.e2e
+def test_e2e_ls_show_hidden(tmp_path: Path, helper: Helper) -> None:
+    # Create files and directories and copy them to storage
+    helper.mkdir("")
+    folder = tmp_path / "folder"
+    folder.mkdir()
+    (folder / "foo").write_bytes(b"foo")
+    (folder / ".bar").write_bytes(b"bar")
+
+    helper.run_cli(
+        [
+            "storage",
+            "cp",
+            "-r",
+            tmp_path.as_uri() + "/folder",
+            helper.tmpstorage
+        ]
+    )
+
+    captured = helper.run_cli(
+        [
+            "storage",
+            "ls",
+            "--all",
+            helper.tmpstorage + "/folder"
+        ]
+    )
+    assert captured.out.splitlines() == ["foo"]


### PR DESCRIPTION
1. Hide names started with a dot by default.
2. Provide `neuro ls -a` option to show all files.