### PR TITLE
Split e2e tests

### DIFF
--- a/.azure-pipelines/stage-e2e.yml
+++ b/.azure-pipelines/stage-e2e.yml
@@ -1,3 +1,14 @@
+paramerters:
+  operation_systems:
+  - '3.6'
+  - '3.7'
+  python_versions:
+  - '3.6'
+  - '3.7'
+  targets:
+  - 'jobs'
+  - 'sumo'
+
 stages:
 - stage: e2e
   displayName: "E2E"
@@ -6,24 +17,36 @@ stages:
     displayName: " "
     strategy:
       matrix:
-        Py36-Linux:
-          python.version: '3.6'
-          image: 'ubuntu-latest'
-        Py37-Linux:
-          python.version: '3.7'
-          image: 'ubuntu-latest'
-        Py36-Win64:
-          python.version: '3.6'
-          image: 'vs2017-win2016'
-        Py37-Win64:
-          python.version: '3.7'
-          image: 'vs2017-win2016'
-        Py36-Mac:
-          python.version: '3.6'
-          image: 'macos-latest'
-        Py37-Mac:
-          python.version: '3.7'
-          image: 'macos-latest'
+        ${{ each py in parameterss.python_versions }}:
+          ${{ each tgt in parameters.targets }}: 
+            ${{ each os in parameters.operation_systems }}:
+              ${{ format('Py-{0}-{1}-{2}', py, os, target) }}:
+                python.version: ${{ py }}
+                ${{ if eq(os, 'Linux') }}:
+                  image: 'ubuntu-latest'
+                ${{ if eq(os, 'Windows') }}:
+                  image: 'windows-latest'
+                ${{ if eq(os, 'Mac') }}:
+                  image: 'macos-latest'
+                target: ${{ format('e2e-{0}', tgt) }}
+        # Py36-Linux:
+        #   python.version: '3.6'
+        #   image: 'ubuntu-latest'
+        # Py37-Linux:
+        #   python.version: '3.7'
+        #   image: 'ubuntu-latest'
+        # Py36-Win64:
+        #   python.version: '3.6'
+        #   image: 'vs2017-win2016'
+        # Py37-Win64:
+        #   python.version: '3.7'
+        #   image: 'vs2017-win2016'
+        # Py36-Mac:
+        #   python.version: '3.6'
+        #   image: 'macos-latest'
+        # Py37-Mac:
+        #   python.version: '3.7'
+        #   image: 'macos-latest'
 
     pool:
       vmImage: $[ variables['image'] ]
@@ -49,7 +72,7 @@ stages:
       displayName: 'Install dependencies'
 
     - script: |
-        make e2e
+        make $(target)
       displayName: 'Run e2e'
       env:
         CLIENT_TEST_E2E_USER_NAME: $(e2e.token)

--- a/.azure-pipelines/stage-e2e.yml
+++ b/.azure-pipelines/stage-e2e.yml
@@ -1,4 +1,4 @@
-paramerters:
+parameters:
   operation_systems:
   - '3.6'
   - '3.7'
@@ -17,7 +17,7 @@ stages:
     displayName: " "
     strategy:
       matrix:
-        ${{ each py in parameterss.python_versions }}:
+        ${{ each py in parameters.python_versions }}:
           ${{ each tgt in parameters.targets }}: 
             ${{ each os in parameters.operation_systems }}:
               ${{ format('Py-{0}-{1}-{2}', py, os, target) }}:

--- a/.azure-pipelines/stage-e2e.yml
+++ b/.azure-pipelines/stage-e2e.yml
@@ -19,8 +19,8 @@ stages:
     strategy:
       matrix:
         ${{ each py in parameters.python_versions }}:
-          ${{ each tgt in parameters.targets }}: 
-            ${{ each os in parameters.operation_systems }}:
+          ${{ each os in parameters.operation_systems }}:
+            ${{ each tgt in parameters.targets }}:
               ${{ format('Py-{0}-{1}-{2}', py, os, tgt) }}:
                 python.version: ${{ py }}
                 image: ${{ format('{0}-latest', os) }}

--- a/.azure-pipelines/stage-e2e.yml
+++ b/.azure-pipelines/stage-e2e.yml
@@ -25,6 +25,7 @@ stages:
                 python.version: ${{ py }}
                 image: ${{ format('{0}-latest', os) }}
                 target: ${{ format('e2e-{0}', tgt) }}
+                PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
 
     pool:
       vmImage: $[ variables['image'] ]
@@ -40,6 +41,11 @@ stages:
         versionSpec: '$(python.version)'
       displayName: "Use Python $(python.version)"
 
+    - task: Cache@2
+      inputs:
+        key: 'pip | "$(Agent.OS)" | "$(python.version)" | requirements/base.txt | requirements/ci.txt'
+        path: $(PIP_CACHE_DIR)
+
     - script: |
         python -m pip install -U pip wheel
       displayName: 'Install prerequirements'
@@ -47,6 +53,7 @@ stages:
     - script: |
         pip install -r requirements/ci.txt pytest-azurepipelines
         pip install .
+        touch .update-deps
       displayName: 'Install dependencies'
 
     - script: |

--- a/.azure-pipelines/stage-e2e.yml
+++ b/.azure-pipelines/stage-e2e.yml
@@ -20,7 +20,7 @@ stages:
         ${{ each py in parameters.python_versions }}:
           ${{ each tgt in parameters.targets }}: 
             ${{ each os in parameters.operation_systems }}:
-              ${{ format('Py-{0}-{1}-{2}', py, os, target) }}:
+              ${{ format('Py-{0}-{1}-{2}', py, os, tgt) }}:
                 python.version: ${{ py }}
                 ${{ if eq(os, 'Linux') }}:
                   image: 'ubuntu-latest'

--- a/.azure-pipelines/stage-e2e.yml
+++ b/.azure-pipelines/stage-e2e.yml
@@ -1,7 +1,8 @@
 parameters:
   operation_systems:
-  - '3.6'
-  - '3.7'
+  - 'ubuntu'
+  - 'windows'
+  - 'macos'
   python_versions:
   - '3.6'
   - '3.7'
@@ -22,12 +23,7 @@ stages:
             ${{ each os in parameters.operation_systems }}:
               ${{ format('Py-{0}-{1}-{2}', py, os, tgt) }}:
                 python.version: ${{ py }}
-                ${{ if eq(os, 'Linux') }}:
-                  image: 'ubuntu-latest'
-                ${{ if eq(os, 'Windows') }}:
-                  image: 'windows-latest'
-                ${{ if eq(os, 'Mac') }}:
-                  image: 'macos-latest'
+                image: ${{ format('{0}-latest', os) }}
                 target: ${{ format('e2e-{0}', tgt) }}
         # Py36-Linux:
         #   python.version: '3.6'

--- a/.azure-pipelines/stage-e2e.yml
+++ b/.azure-pipelines/stage-e2e.yml
@@ -25,24 +25,6 @@ stages:
                 python.version: ${{ py }}
                 image: ${{ format('{0}-latest', os) }}
                 target: ${{ format('e2e-{0}', tgt) }}
-        # Py36-Linux:
-        #   python.version: '3.6'
-        #   image: 'ubuntu-latest'
-        # Py37-Linux:
-        #   python.version: '3.7'
-        #   image: 'ubuntu-latest'
-        # Py36-Win64:
-        #   python.version: '3.6'
-        #   image: 'vs2017-win2016'
-        # Py37-Win64:
-        #   python.version: '3.7'
-        #   image: 'vs2017-win2016'
-        # Py36-Mac:
-        #   python.version: '3.6'
-        #   image: 'macos-latest'
-        # Py37-Mac:
-        #   python.version: '3.7'
-        #   image: 'macos-latest'
 
     pool:
       vmImage: $[ variables['image'] ]
@@ -69,7 +51,7 @@ stages:
 
     - script: |
         make $(target)
-      displayName: 'Run e2e'
+      displayName: 'Run $(target)'
       env:
         CLIENT_TEST_E2E_USER_NAME: $(e2e.token)
         PYTEST_XDIST_NUM_THREADS: 8

--- a/.azure-pipelines/stage-unit.yml
+++ b/.azure-pipelines/stage-unit.yml
@@ -37,13 +37,16 @@ stages:
         versionSpec: '$(python.version)'
       displayName: "Use Python $(python.version)"
 
+    - task: Cache@2
+      inputs:
+        key: 'pip | "$(Agent.OS)" | "$(python.version)" | requirements/base.txt | requirements/ci.txt'
+        path: $(PIP_CACHE_DIR)
+
     - script: |
-        echo "Pip cache $PIP_CACHE_DIR"
         python -m pip install -U pip wheel
       displayName: 'Install prerequirements'
 
     - script: |
-        echo "Pip cache $PIP_CACHE_DIR"
         pip install -r requirements/ci.txt pytest-azurepipelines
         pip install .
         touch .update-deps

--- a/.azure-pipelines/stage-unit.yml
+++ b/.azure-pipelines/stage-unit.yml
@@ -43,8 +43,10 @@ stages:
       displayName: 'Install prerequirements'
 
     - script: |
+        echo "Pip cache $PIP_CACHE_DIR"
         pip install -r requirements/ci.txt pytest-azurepipelines
         pip install .
+        touch .update-deps
       displayName: 'Install dependencies'
 
     - script: |

--- a/.azure-pipelines/stage-unit.yml
+++ b/.azure-pipelines/stage-unit.yml
@@ -1,3 +1,13 @@
+parameters:
+  operation_systems:
+  - 'ubuntu'
+  - 'windows'
+  - 'macos'
+  python_versions:
+  - '3.6'
+  - '3.7'
+
+
 stages:
 - stage: test
   displayName: "Unit"
@@ -6,24 +16,11 @@ stages:
     displayName: " "
     strategy:
       matrix:
-        Py36-Linux:
-          python.version: '3.6'
-          image: 'ubuntu-latest'
-        Py37-Linux:
-          python.version: '3.7'
-          image: 'ubuntu-latest'
-        Py36-Win64:
-          python.version: '3.6'
-          image: 'vs2017-win2016'
-        Py37-Win64:
-          python.version: '3.7'
-          image: 'vs2017-win2016'
-        Py36-Mac:
-          python.version: '3.6'
-          image: 'macos-latest'
-        Py37-Mac:
-          python.version: '3.7'
-          image: 'macos-latest'
+        ${{ each py in parameters.python_versions }}:
+          ${{ each os in parameters.operation_systems }}:
+            ${{ format('Py-{0}-{1}', py, os) }}:
+              python.version: ${{ py }}
+              image: ${{ format('{0}-latest', os) }}
 
     pool:
       vmImage: $[ variables['image'] ]

--- a/.azure-pipelines/stage-unit.yml
+++ b/.azure-pipelines/stage-unit.yml
@@ -21,6 +21,7 @@ stages:
             ${{ format('Py-{0}-{1}', py, os) }}:
               python.version: ${{ py }}
               image: ${{ format('{0}-latest', os) }}
+              PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
 
     pool:
       vmImage: $[ variables['image'] ]
@@ -37,6 +38,7 @@ stages:
       displayName: "Use Python $(python.version)"
 
     - script: |
+        echo "Pip cache $PIP_CACHE_DIR"
         python -m pip install -U pip wheel
       displayName: 'Install prerequirements'
 

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,30 @@ e2e: .update-deps
 		--durations 10 \
 		tests
 
+.PHONY: e2e-jobs
+e2e-jobs: .update-deps
+	pytest \
+	    -n ${PYTEST_XDIST_NUM_THREADS} \
+		-m "e2e and e2e_job" \
+		--cov=neuromation \
+		--cov-report term-missing:skip-covered \
+		--cov-report xml:coverage.xml \
+		--verbose \
+		--durations 10 \
+		tests
+
+.PHONY: e2e-sumo
+e2e-sumo: .update-deps
+	pytest \
+	    -n ${PYTEST_XDIST_NUM_THREADS} \
+		-m "e2e and not e2e_job" \
+		--cov=neuromation \
+		--cov-report term-missing:skip-covered \
+		--cov-report xml:coverage.xml \
+		--verbose \
+		--durations 10 \
+		tests
+
 
 .PHONY: test
 test: .update-deps

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,6 +5,7 @@ log_level=INFO
 junit_family=xunit2
 markers =
   e2e
+  e2e_job
 filterwarnings=error
   ignore::DeprecationWarning:yaml
   ignore:returning HTTPException object is deprecated.+:DeprecationWarning:aiodocker

--- a/tests/e2e/test_e2e_jobs.py
+++ b/tests/e2e/test_e2e_jobs.py
@@ -20,6 +20,8 @@ from tests.e2e.conftest import CLIENT_TIMEOUT, Helper
 from tests.e2e.utils import JOB_TINY_CONTAINER_PARAMS, JOB_TINY_CONTAINER_PRESET
 
 
+pytestmark = pytest.mark.e2e_job
+
 ALPINE_IMAGE_NAME = "alpine:latest"
 UBUNTU_IMAGE_NAME = "ubuntu:latest"
 NGINX_IMAGE_NAME = "nginx:latest"


### PR DESCRIPTION
Split e2e tests into two smaller subsets.
It allows waiting for less time and restarting less amount of tests in a case of failure.