### PR TITLE
make gcs-nfs default storage in admin generate-cluster-config

### DIFF
--- a/neuromation/cli/admin.py
+++ b/neuromation/cli/admin.py
@@ -148,8 +148,7 @@ node_pools:
   min_size: 0
   max_size: 1
 storage:
-  id: standard
-  capacity_tb: 1
+  id: gcs-nfs
 """
 
 


### PR DESCRIPTION
closes #1293 