### PR TITLE
Simplify progress queue in Storage a little

### DIFF
--- a/neuromation/api/abc.py
+++ b/neuromation/api/abc.py
@@ -9,22 +9,26 @@ from .parsing_utils import LocalImage, RemoteImage
 # storage
 
 
+class StorageProgressEvent:
+    pass
+
+
 @dataclass(frozen=True)
-class StorageProgressStart:
+class StorageProgressStart(StorageProgressEvent):
     src: URL
     dst: URL
     size: int
 
 
 @dataclass(frozen=True)
-class StorageProgressComplete:
+class StorageProgressComplete(StorageProgressEvent):
     src: URL
     dst: URL
     size: int
 
 
 @dataclass(frozen=True)
-class StorageProgressStep:
+class StorageProgressStep(StorageProgressEvent):
     src: URL
     dst: URL
     current: int
@@ -32,19 +36,19 @@ class StorageProgressStep:
 
 
 @dataclass(frozen=True)
-class StorageProgressEnterDir:
+class StorageProgressEnterDir(StorageProgressEvent):
     src: URL
     dst: URL
 
 
 @dataclass(frozen=True)
-class StorageProgressLeaveDir:
+class StorageProgressLeaveDir(StorageProgressEvent):
     src: URL
     dst: URL
 
 
 @dataclass(frozen=True)
-class StorageProgressFail:
+class StorageProgressFail(StorageProgressEvent):
     src: URL
     dst: URL
     message: str

--- a/neuromation/api/storage.py
+++ b/neuromation/api/storage.py
@@ -19,7 +19,6 @@ from typing import (
     Iterable,
     List,
     Optional,
-    Tuple,
     cast,
 )
 


### PR DESCRIPTION
I found the queue containing only a single object and None to specify closure to work much simpler. Thoughts?