### PR TITLE
Patch steal_config_maybe()

### DIFF
--- a/CHANGELOG.D/1415.bug
+++ b/CHANGELOG.D/1415.bug
@@ -1,0 +1,1 @@
+Fix `--pass-config` error: File exists: '/root/.neuro'.

--- a/neuromation/cli/utils.py
+++ b/neuromation/cli/utils.py
@@ -735,8 +735,10 @@ def pager_maybe(
 def steal_config_maybe(dst_path: pathlib.Path) -> None:
     if NEURO_STEAL_CONFIG in os.environ:
         src = pathlib.Path(os.environ[NEURO_STEAL_CONFIG])
+        if not src.exists():
+            return
         dst = Factory(dst_path).path
-        dst.mkdir(mode=0o700)
+        dst.mkdir(mode=0o700, exist_ok=True)
         for f in src.iterdir():
             target = dst / f.name
             shutil.copy(f, target)

--- a/neuromation/cli/utils.py
+++ b/neuromation/cli/utils.py
@@ -738,7 +738,7 @@ def steal_config_maybe(dst_path: pathlib.Path) -> None:
         if not src.exists():
             return
         dst = Factory(dst_path).path
-        dst.mkdir(mode=0o700, exist_ok=True)
+        dst.mkdir(mode=0o700)
         for f in src.iterdir():
             target = dst / f.name
             shutil.copy(f, target)


### PR DESCRIPTION
This is the fix for the problem I faced while trying to make `neuro` work from ML Recipes submitted from Web UI buttons.

```
env:
NEURO_STEAL_CONFIG=/var/storage/.neuro/8bf16cc4-1955-4c21-a5ae-522b00a596ae-cfg
NEUROMATION_CONFIG=/var/storage/nmrc/2e58436a-1391-435e-8f46-1dab15f233d5-nmrc
```
I run the job, `neuro config show` works first few times, then it raises exception:
```
ERROR: I/O Error ([Errno 17] File exists: '/var/storage/nmrc/2e58436a-1391-435e-8f46-1dab15f233d5-nmrc')
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/neuromation/cli/main.py", line 490, in main
    cli.main(args=args, standalone_mode=False)
  File "/usr/local/lib/python3.6/dist-packages/click/core.py", line 716, in main
    with self.make_context(prog_name, args, **extra) as ctx:
  File "/usr/local/lib/python3.6/dist-packages/neuromation/cli/main.py", line 147, in make_context
    steal_config_maybe(Path(kwargs["neuromation_config"]))
  File "/usr/local/lib/python3.6/dist-packages/neuromation/cli/utils.py", line 739, in steal_config_maybe
    dst.mkdir(mode=0o700)
  File "/usr/lib/python3.6/pathlib.py", line 1248, in mkdir
    self._accessor.mkdir(self, mode)
  File "/usr/lib/python3.6/pathlib.py", line 387, in wrapped
    return strfunc(str(pathobj), *args)
FileExistsError: [Errno 17] File exists: '/var/storage/nmrc/2e58436a-1391-435e-8f46-1dab15f233d5-nmrc'
```
After I applied the patch, `neuro` worked.


Note: current `neuromation/base` does not have latest version of `neuromation==20.3.18`. I tested this as following:
1. Run a job from `neuromation/base`, update client there
2. save this job to another image
3. run another job from the new image and observe described behaviour.