### PR TITLE
Make sure glob does not consume recursive directories

### DIFF
--- a/docs/blob_storage_reference.rst
+++ b/docs/blob_storage_reference.rst
@@ -1,15 +1,15 @@
 .. _blob-storage-reference:
 
-============================
+==========================
 Blob Storage API Reference
-============================
+==========================
 
 
 .. currentmodule:: neuromation.api
 
 
 Blob Storage
-==============
+============
 
 .. note::
    Be careful with using trailing slashes in Blob Storage URL's, keys and prefixes.
@@ -42,24 +42,23 @@ Blob Storage
 
    .. comethod:: list_blobs(bucket_name: str, prefix: str = "", \
                               recursive: bool = False, max_keys: int = 10000 \
-                  ) -> List[Union[BlobListing, PrefixListing]]
+                  ) -> Tuple[Sequence[BlobListing], Sequence[PrefixListing]]
 
       List blobs in the bucket. You can filter by prefix and return results similar
       to a folder structure if ``recursive=False`` is provided ::
 
-         content = await client.blob_storage.list_blobs(
+         blobs, prefixes = await client.blob_storage.list_blobs(
             bucket_name="my_bucket",
             recursive=False,
             prefix="parent/"
          )
-         for blob in content:
-            if isinstance(blob, BlobListing):
-               print("File ", blob.key)
-            else:
-               print("Folder ", blob.prefix)
+         for blob in blobs:
+            print("File ", blob.key)
+         for folder in prefixes:
+            print("Folder ", folder.prefix)
 
       :param str bucket_name: Name of the bucket.
-      :param str prefix: Filter results by a prefix in it's key.
+      :param str prefix: Filter results by a prefix of it's key.
       :param recursive bool: If ``True`` listing will contain *all* keys filtered by
           prefix, while with ``False`` only ones up to next ``/`` will be returned.
           To indicate missing keys, all that were listed will be combined under a
@@ -293,7 +292,7 @@ BucketListing
 
 
 BlobListing
-=============
+===========
 
 .. class:: BlobListing
 
@@ -344,7 +343,7 @@ PrefixListing
       ``blob:my_bucket/my_folder/``.
 
 Blob
-======
+====
 
 .. class:: Blob
 

--- a/docs/storage_usage.rst
+++ b/docs/storage_usage.rst
@@ -13,9 +13,9 @@ scenarios like uploading / downloading directories recursively.
 
 There are many methods in :class:`Storage` namespace, here we describe a few.
 
-Object Storage API (available as :attr:`Client.object_storage`) is another subsystem,
+Blob Storage API (available as :attr:`Client.blob_storage`) is another subsystem,
 which has a similar Upload/Download interface as methods shown below. Please refer to
-:class:`ObjectStorage` documentation for more details.
+:class:`BlobStorage` documentation for more details.
 
 
 Upload a Folder

--- a/neuromation/api/blob_storage.py
+++ b/neuromation/api/blob_storage.py
@@ -278,7 +278,7 @@ class BlobStorage(metaclass=NoPublicConstructor):
             return
 
         has_magic = _has_magic(part)
-        # Optimize the prefix for matchin. If we have a pattern `folder1/b*/*.json`
+        # Optimize the prefix for matching. If we have a pattern `folder1/b*/*.json`
         # it's better to scan with prefix `folder1/b` on the 2nd step, not `folder1/`
         if has_magic:
             opt_prefix = prefix + _glob_safe_prefix(part)

--- a/neuromation/api/blob_storage.py
+++ b/neuromation/api/blob_storage.py
@@ -17,6 +17,7 @@ from typing import (
     Dict,
     List,
     Optional,
+    Sequence,
     Tuple,
     Union,
     cast,
@@ -39,7 +40,15 @@ from .abc import (
 )
 from .config import Config
 from .core import ResourceNotFound, _Core
-from .storage import QueuedProgress, _always, _has_magic, run_concurrently, run_progress
+from .file_filter import translate
+from .storage import (
+    QueuedProgress,
+    _always,
+    _has_magic,
+    _magic_check,
+    run_concurrently,
+    run_progress,
+)
 from .url_utils import _extract_path, normalize_blob_path_uri, normalize_local_path_uri
 from .users import Action
 from .utils import NoPublicConstructor, asynccontextmanager, retries
@@ -137,9 +146,6 @@ class PrefixListing:
         return True
 
 
-ListResult = Union[PrefixListing, BlobListing]
-
-
 class Blob:
     def __init__(self, resp: aiohttp.ClientResponse, stats: BlobListing):
         self._resp = resp
@@ -154,7 +160,7 @@ class BlobStorage(metaclass=NoPublicConstructor):
     def __init__(self, core: _Core, config: Config) -> None:
         self._core = core
         self._config = config
-        self._max_keys = 10000
+        self._default_batch_size = 1000
         self._file_sem = asyncio.BoundedSemaphore(MAX_OPEN_FILES)
 
     async def list_buckets(self) -> List[BucketListing]:
@@ -184,92 +190,138 @@ class BlobStorage(metaclass=NoPublicConstructor):
         bucket_name: str,
         prefix: str = "",
         recursive: bool = False,
-        max_keys: int = 10000,
-    ) -> List[ListResult]:
+        max_keys: Optional[int] = None,
+    ) -> Tuple[Sequence[BlobListing], Sequence[PrefixListing]]:
+        contents: List[BlobListing] = []
+        common_prefixes: List[PrefixListing] = []
+
+        async for blobs, prefixes in self._iter_blob_pages(
+            bucket_name, prefix, recursive=recursive, max_keys=max_keys
+        ):
+            contents.extend(blobs)
+            common_prefixes.extend(prefixes)
+        return contents, common_prefixes
+
+    async def _iter_blob_pages(
+        self,
+        bucket_name: str,
+        prefix: str = "",
+        *,
+        recursive: bool = False,
+        batch_size: Optional[int] = None,
+        max_keys: Optional[int] = None,
+    ) -> AsyncIterator[Tuple[Sequence[BlobListing], Sequence[PrefixListing]]]:
         url = self._config.blob_storage_url / "o" / bucket_name
         auth = await self._config._api_auth()
+        if batch_size is None:
+            batch_size = self._default_batch_size
 
-        query = {"recursive": str(recursive).lower(), "max_keys": str(self._max_keys)}
+        # 1st page may be less then max_keys
+        next_page_size = batch_size
+        if max_keys is not None:
+            next_page_size = min(batch_size, max_keys)
+
+        query = {"recursive": str(recursive).lower(), "max_keys": str(next_page_size)}
         if prefix:
             query["prefix"] = prefix
         url = url.with_query(query)
 
-        contents: List[ListResult] = []
-        common_prefixes: List[ListResult] = []
         while True:
             async with self._core.request("GET", url, auth=auth) as resp:
                 res = await resp.json()
-                contents.extend(
-                    [_blob_status_from_key(bucket_name, key) for key in res["contents"]]
-                )
-                common_prefixes.extend(
-                    [
-                        _blob_status_from_prefix(bucket_name, prefix)
-                        for prefix in res["common_prefixes"]
-                    ]
-                )
-                if res["is_truncated"] and res["contents"]:
-                    start_after = res["contents"][-1]["key"]
-                    url = url.update_query(start_after=start_after)
-                else:
-                    break
-        return common_prefixes + contents
+            contents = [
+                _blob_status_from_key(bucket_name, key) for key in res["contents"]
+            ]
 
-    async def glob_blobs(self, bucket_name: str, pattern: str) -> List[BlobListing]:
-        pattern = pattern.lstrip("/")
-        parts = pattern.split("/")
+            common_prefixes = [
+                _blob_status_from_prefix(bucket_name, prefix)
+                for prefix in res["common_prefixes"]
+            ]
+            yield contents, common_prefixes
 
-        # Limit the search to prefix of keys
-        prefix = ""
-        for part in parts:
-            if _has_magic(part):
+            if res["is_truncated"] and res["contents"]:
+                start_after = res["contents"][-1]["key"]
+                url = url.update_query(start_after=start_after)
+                # Limit the next page if we are reaching max_keys limit
+                if max_keys is not None:
+                    max_keys -= len(contents) + len(common_prefixes)
+                    if max_keys <= 0:
+                        break
+                    next_page_size = min(max_keys, batch_size)
+                    url = url.update_query(max_keys=str(next_page_size))
+            else:
                 break
+
+    async def glob_blobs(
+        self, bucket_name: str, pattern: str
+    ) -> AsyncIterator[BlobListing]:
+        pattern = pattern.lstrip("/")
+
+        async for blob in self._glob_search(bucket_name, "", pattern):
+            yield blob
+
+    async def _glob_search(
+        self, bucket_name: str, prefix: str, pattern: str
+    ) -> AsyncIterator[BlobListing]:
+        part, _, remaining = pattern.partition("/")
+
+        # Yield all remaining files recursively, as *all* keys may match the query
+        # **/.json
+        if _isrecursive(part):
+            full_match = re.compile(translate(pattern)).fullmatch
+            async for blobs, prefixes in self._iter_blob_pages(
+                bucket_name, prefix, recursive=True
+            ):
+                assert not prefixes, "No prefixes in recursive mode"
+                for blob in blobs:
+                    if full_match(blob.key[len(prefix) :]):
+                        yield blob
+            return
+
+        has_magic = _has_magic(part)
+        # Optimize the prefix for matchin. If we have a pattern `folder1/b*/*.json`
+        # it's better to scan with prefix `folder1/b` on the 2nd step, not `folder1/`
+        if has_magic:
+            opt_prefix = prefix + _glob_safe_prefix(part)
+            match = re.compile(translate(part)).fullmatch
+
+        # If this is the last part in the search pattern we have to scan keys, not
+        # just prefixes
+        if not remaining:
+            if has_magic:
+                async for blobs, _ in self._iter_blob_pages(
+                    bucket_name, opt_prefix, recursive=False
+                ):
+                    for blob in blobs:
+                        if match(blob.name):
+                            yield blob
             else:
-                prefix += part + "/"
+                try:
+                    blob = await self.head_blob(bucket_name, prefix + part)
+                    yield blob
+                except ResourceNotFound:
+                    pass
+            return
 
-        # Prepare matcher for full key path
-        matcher_parts: List[str] = []
-        recursive = False
-        for part in parts:
-            if part == "**":
-                matcher_parts.append(".*")
-                recursive = True
-            elif _has_magic(part):
-                part_re = fnmatch.translate(part)
-                assert part_re.endswith(r"\Z")
-                part_re = part_re[:-2]  # Cut the \Z part
-                matcher_parts.append(part_re)
-            else:
-                matcher_parts.append(re.escape(part))
-
-        match: Callable[..., Any]
-        if not recursive:
-            # We need to match exactly for each path level, so that "*.json" does not
-            # match all folders
-            matchers = [re.compile(p).fullmatch for p in matcher_parts]
-
-            def match(key: str) -> bool:
-                parts = key.split("/")
-                for matcher, part in itertools.zip_longest(matchers, parts):
-                    if part is None or matcher is None:
-                        return False
-                    if not matcher(part):
-                        return False
-                return True
+        # We can be sure no blobs on this level will match the pattern, as results are
+        # deeper down the tree. Recursively scan folders only.
+        if has_magic:
+            async for blobs, prefixes in self._iter_blob_pages(
+                bucket_name, opt_prefix, recursive=False
+            ):
+                for folder in prefixes:
+                    if not match(folder.name):
+                        continue
+                    async for blob in self._glob_search(
+                        bucket_name, folder.prefix, remaining
+                    ):
+                        yield blob
 
         else:
-            matcher = "/".join(matcher_parts) + r"\Z"
-            match = re.compile(matcher).fullmatch
-
-        res = []
-        for blob_status in await self.list_blobs(
-            bucket_name, prefix=prefix, recursive=True
-        ):
-            # We don't have PrefixListing if recursive is used
-            blob_status = cast(BlobListing, blob_status)
-            if match(blob_status.key):
-                res.append(blob_status)
-        return res
+            async for blob in self._glob_search(
+                bucket_name, prefix + part + "/", remaining
+            ):
+                yield blob
 
     async def head_blob(self, bucket_name: str, key: str) -> BlobListing:
         url = self._config.blob_storage_url / "o" / bucket_name / key
@@ -377,10 +429,10 @@ class BlobStorage(metaclass=NoPublicConstructor):
         # Check if a folder key exists. As `/` at the end makes a different key, make
         # sure we ask for one with ending slash.
         bucket_name, key = self._extract_bucket_and_key(uri)
-        blobs = await self.list_blobs(
+        blobs, prefixes = await self.list_blobs(
             bucket_name=bucket_name, prefix=key + "/", recursive=False, max_keys=1
         )
-        return bool(blobs)
+        return blobs or prefixes
 
     async def _mkdir(self, uri: URL) -> None:
         bucket_name, key = self._extract_bucket_and_key(uri)
@@ -628,11 +680,13 @@ class BlobStorage(metaclass=NoPublicConstructor):
             prefix_path += "/"
         for retry in retries(f"Fail to list {src}"):
             async with retry:
-                folder = await self.list_blobs(
+                blobs, prefixes = await self.list_blobs(
                     bucket_name=bucket_name, prefix=prefix_path, recursive=False
                 )
 
-        for child in folder:
+        for child in itertools.chain(blobs, prefixes):
+            child = cast(Union[PrefixListing, BlobListing], child)
+
             # Skip "folder" keys, as they will be returned as BlobListing results again,
             # previously being a common prefix, ie. PrefixListing.
             if child.path == prefix_path:
@@ -667,6 +721,14 @@ class BlobStorage(metaclass=NoPublicConstructor):
                 )
         await run_concurrently(tasks)
         await progress.leave(StorageProgressLeaveDir(src, dst))
+
+
+def _glob_safe_prefix(pattern: str) -> str:
+    return _magic_check.split(pattern, 1)[0]
+
+
+def _isrecursive(pattern: str) -> bool:
+    return pattern == "**"
 
 
 def _bucket_status_from_data(data: Dict[str, Any]) -> BucketListing:

--- a/neuromation/api/blob_storage.py
+++ b/neuromation/api/blob_storage.py
@@ -1,7 +1,6 @@
 import asyncio
 import base64
 import errno
-import fnmatch
 import hashlib
 import itertools
 import re
@@ -432,7 +431,7 @@ class BlobStorage(metaclass=NoPublicConstructor):
         blobs, prefixes = await self.list_blobs(
             bucket_name=bucket_name, prefix=key + "/", recursive=False, max_keys=1
         )
-        return blobs or prefixes
+        return bool(blobs) or bool(prefixes)
 
     async def _mkdir(self, uri: URL) -> None:
         bucket_name, key = self._extract_bucket_and_key(uri)

--- a/neuromation/api/blob_storage.py
+++ b/neuromation/api/blob_storage.py
@@ -238,9 +238,9 @@ class BlobStorage(metaclass=NoPublicConstructor):
             ]
             yield contents, common_prefixes
 
-            if res["is_truncated"] and res["contents"]:
-                start_after = res["contents"][-1]["key"]
-                url = url.update_query(start_after=start_after)
+            if res["is_truncated"]:
+                continuation_token = res["continuation_token"]
+                url = url.update_query(continuation_token=continuation_token)
                 # Limit the next page if we are reaching max_keys limit
                 if max_keys is not None:
                     max_keys -= len(contents) + len(common_prefixes)

--- a/tests/api/test_blob_storage.py
+++ b/tests/api/test_blob_storage.py
@@ -497,7 +497,6 @@ async def test_blob_storage_glob_blobs(
 
     async with make_client(srv.make_url("/")) as client:
         ret = await client.blob_storage.glob_blobs(bucket_name, pattern="folder1/*")
-
         assert ret == [
             BlobListing(
                 key="folder1/xxx.txt",
@@ -513,25 +512,17 @@ async def test_blob_storage_glob_blobs(
             ),
         ]
 
-        ret = await client.blob_storage.glob_blobs(bucket_name, pattern="**.json")
-
+        ret = await client.blob_storage.glob_blobs(bucket_name, pattern="**/*.json")
         assert ret == [
             BlobListing(
                 key="folder1/yyy.json",
                 size=2,
                 modification_time=int(mtime2.timestamp()),
                 bucket_name=bucket_name,
-            ),
-            BlobListing(
-                key="test.json",
-                size=213,
-                modification_time=int(mtime1.timestamp()),
-                bucket_name="foo",
-            ),
+            )
         ]
 
         ret = await client.blob_storage.glob_blobs(bucket_name, pattern="*/*.txt")
-
         assert ret == [
             BlobListing(
                 key="folder1/xxx.txt",
@@ -542,7 +533,6 @@ async def test_blob_storage_glob_blobs(
         ]
 
         ret = await client.blob_storage.glob_blobs(bucket_name, pattern="test[1-9].*")
-
         assert ret == [
             BlobListing(
                 key="test1.txt",


### PR DESCRIPTION
I know the fix is a bit hacky, but can't find a better way for now. Tried to do a recursive iteration, as it's done in storage but it did not perform very well, it needs some attention to do it right. What do you think of this fast fix for now?

This is the related function in gsutil:
https://github.com/GoogleCloudPlatform/gsutil/blob/master/gslib/wildcard_iterator.py
Quite a lot of edge cases as it seems.