### PR TITLE
Make filter patterns more compatible with .gitignore.

### DIFF
--- a/CHANGELOG.D/1444.feature
+++ b/CHANGELOG.D/1444.feature
@@ -1,0 +1,1 @@
+Filter patterns are now more compatible with `.gitignore`. Added support of `**` which matches zero or more path components. `?` and `*` no longer match `/`. Patterns which does not contain `/` at the beginning or middle matches now files in subdirectories.

--- a/neuromation/api/file_filter.py
+++ b/neuromation/api/file_filter.py
@@ -1,4 +1,3 @@
-import fnmatch
 import re
 from typing import Any, Callable, List, Tuple, cast
 
@@ -8,8 +7,12 @@ class FileFilter:
         self.filters: List[Tuple[bool, Callable[[str], Any]]] = []
 
     def append(self, exclude: bool, pattern: str) -> None:
-        re_pattern = fnmatch.translate(pattern)
-        matcher = cast(Callable[[str], Any], re.compile(re_pattern).match)
+        if "/" not in pattern.rstrip("/"):
+            pattern = "**/" + pattern
+        re_pattern = translate(pattern)
+        matcher = cast(
+            Callable[[str], Any], re.compile(re_pattern, re.DOTALL).fullmatch
+        )
         self.filters.append((exclude, matcher))
 
     def exclude(self, pattern: str) -> None:
@@ -24,3 +27,76 @@ class FileFilter:
             if result == exclude and matcher(path):
                 result = not result
         return result
+
+
+def translate(pat: str) -> str:
+    """Translate a shell PATTERN to a regular expression.
+    """
+
+    i = 0
+    n = len(pat)
+    res = ""
+    while i < n:
+        c = pat[i]
+        i += 1
+        if c == "*":
+            if (
+                (not res or res[-1] == "/")
+                and i < n
+                and pat[i] == "*"
+                and (i + 1 == n or pat[i + 1] == "/")
+            ):
+                # ** between slashes or ends of the pattern
+                if i + 1 == n:
+                    res += ".*"
+                else:
+                    res += "(?:.+/)?"
+                i += 2
+            else:
+                # Any other *
+                res += "[^/]*"
+        elif c == "?":
+            res += "[^/]"
+        elif c == "/":
+            res += "/"
+        elif c == "[":
+            j = i
+            if j < n and pat[j] == "!":
+                j += 1
+            if j < n and pat[j] == "]":
+                j += 1
+            while j < n and pat[j] != "]":
+                j += 1
+            if j >= n:
+                res += "\\["
+            else:
+                stuff = pat[i:j]
+                if "--" not in stuff:
+                    stuff = stuff.replace("\\", r"\\")
+                else:
+                    chunks = []
+                    k = i + 2 if pat[i] == "!" else i + 1
+                    while True:
+                        k = pat.find("-", k, j)
+                        if k < 0:
+                            break
+                        chunks.append(pat[i:k])
+                        i = k + 1
+                        k = k + 3
+                    chunks.append(pat[i:j])
+                    # Escape backslashes and hyphens for set difference (--).
+                    # Hyphens that create ranges shouldn't be escaped.
+                    stuff = "-".join(
+                        s.replace("\\", r"\\").replace("-", r"\-") for s in chunks
+                    )
+                # Escape set operations (&&, ~~ and ||).
+                stuff = re.sub(r"([&~|])", r"\\\1", stuff)
+                i = j + 1
+                if stuff[0] == "!":
+                    stuff = "^" + stuff[1:]
+                elif stuff[0] in ("^", "["):
+                    stuff = "\\" + stuff
+                res = "%s[%s]" % (res, stuff)
+        else:
+            res += re.escape(c)
+    return res

--- a/tests/api/test_file_filter.py
+++ b/tests/api/test_file_filter.py
@@ -1,6 +1,4 @@
-import os.path
-
-from neuromation.api.file_filter import FileFilter
+from neuromation.api.file_filter import FileFilter, translate
 
 
 async def test_empty_filter() -> None:
@@ -8,7 +6,6 @@ async def test_empty_filter() -> None:
     assert await ff.match("spam")
     assert await ff.match(".spam")
     assert await ff.match("spam/ham")
-    assert await ff.match(os.path.join("spam", "ham"))
 
 
 async def test_exclude_all() -> None:
@@ -23,6 +20,9 @@ async def test_exclude() -> None:
     ff.exclude("*.txt")
     assert await ff.match("spam")
     assert not await ff.match("spam.txt")
+    assert not await ff.match("dir/spam.txt")
+    assert await ff.match("dir.txt/spam")
+    assert await ff.match("dir/child.txt/spam")
 
 
 async def test_exclude_include() -> None:
@@ -33,3 +33,71 @@ async def test_exclude_include() -> None:
     assert await ff.match("spam.txt")
     assert await ff.match("ham")
     assert not await ff.match("ham.txt")
+    assert await ff.match("dir/spam.txt")
+    assert not await ff.match("dir/ham.txt")
+    assert await ff.match("dir.txt/spam")
+
+
+async def test_exclude_with_slash() -> None:
+    ff = FileFilter()
+    ff.exclude("dir/*.txt")
+    assert await ff.match("spam.txt")
+    assert not await ff.match("dir/spam.txt")
+    assert await ff.match("parent/dir/spam.txt")
+
+
+async def test_exclude_recursive() -> None:
+    ff = FileFilter()
+    ff.exclude("**/dir/*.txt")
+    assert await ff.match("spam.txt")
+    assert not await ff.match("dir/spam.txt")
+    assert await ff.match("dir/spam")
+    assert not await ff.match("parent/dir/spam.txt")
+    assert await ff.match("parent/dir/spam")
+
+    ff = FileFilter()
+    ff.exclude("dir/**/*.txt")
+    assert await ff.match("spam.txt")
+    assert not await ff.match("dir/spam.txt")
+    assert await ff.match("dir/spam")
+    assert not await ff.match("dir/child/spam.txt")
+    assert await ff.match("dir/child/spam")
+
+    ff = FileFilter()
+    ff.exclude("dir/**")
+    assert await ff.match("spam")
+    assert not await ff.match("dir/")
+    assert await ff.match("dir")
+    assert not await ff.match("dir/child")
+    assert not await ff.match("dir/child/spam")
+
+    ff = FileFilter()
+    ff.exclude("dir/**/")
+    assert await ff.match("spam")
+    assert not await ff.match("dir/")
+    assert await ff.match("dir")
+    assert not await ff.match("dir/child/")
+    assert await ff.match("dir/child")
+    assert not await ff.match("dir/child/spam/")
+    assert await ff.match("dir/child/spam")
+
+
+def test_translate() -> None:
+    assert translate("") == ""
+    assert translate("abc") == "abc"
+    assert translate("a?c") == "a[^/]c"
+    assert translate("a*c") == "a[^/]*c"
+    assert translate("a[bc]d") == "a[bc]d"
+    assert translate("a[b-d]e") == "a[b-d]e"
+    assert translate("a[!b-d]e") == "a[^b-d]e"
+    assert translate("[a-zA-Z_]") == "[a-zA-Z_]"
+
+
+def test_translate_recursive() -> None:
+    assert translate("**") == ".*"
+    assert translate("**/") == f"(?:.+/)?"
+    assert translate("**/abc") == f"(?:.+/)?abc"
+    assert translate("/**") == f"/.*"
+    assert translate("abc/**") == f"abc/.*"
+    assert translate("/**/") == f"/(?:.+/)?"
+    assert translate("abc/**/def") == f"abc/(?:.+/)?def"


### PR DESCRIPTION
* Make `?` and `*` not matching `/`.
* Add support of `**` for recursive matching.
* Make patterns not containing slashes except the trailing slashes recursive (virtually prepend implicit `**/` to them).

Closes #1444.