### PR TITLE
Make exit code of 'job run' command more reliable

### DIFF
--- a/CHANGELOG.D/1470.bugfix
+++ b/CHANGELOG.D/1470.bugfix
@@ -1,0 +1,1 @@
+Make exit code of `job run` command more reliable.

--- a/neuromation/cli/job.py
+++ b/neuromation/cli/job.py
@@ -1122,7 +1122,6 @@ async def run_job(
     if browse and job.status != JobStatus.FAILED:
         await browse_job(root, job)
 
-    exit_code = None
     if not detach:
         if not root.quiet:
             msg = textwrap.dedent(
@@ -1135,15 +1134,15 @@ async def run_job(
             click.echo(click.style(msg, dim=True))
         await _print_logs(root, job.id)
         job = await root.client.jobs.status(job.id)
-        exit_code = job.history.exit_code
+        while job.history.exit_code is None:
+            await asyncio.sleep(0.1)
+            job = await root.client.jobs.status(job.id)
+        sys.exit(job.history.exit_code)
     else:
         # Even if we detached, but the job has failed to start
         # (most common reason - no resources), the command fails
         if job.status == JobStatus.FAILED:
-            exit_code = EX_PLATFORMERROR
-
-    if exit_code is not None:
-        sys.exit(exit_code)
+            sys.exit(EX_PLATFORMERROR)
 
     return job
 


### PR DESCRIPTION
Fix #1470