### PR TITLE
Apply external version control utility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,7 @@ test-all: .update-deps
 
 .PHONY: lint
 lint: lint-docs
+	./build-tools/version.py check
 	isort -c -rc ${ISORT_DIRS}
 	black --check $(BLACK_DIRS)
 	mypy $(MYPY_DIRS)
@@ -144,6 +145,7 @@ publish-lint:
 
 .PHONY: format fmt
 format fmt:
+	./build-tools/version.py update
 	isort -rc $(ISORT_DIRS)
 	black $(BLACK_DIRS)
 	# generate docs as the last stage to allow reformat code first

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@
 
 * Make sure that the code is in a good shape, all tests are passed etc.
 * Switch to `master` branch (`git checkout master`).
-* Open `neuromation/__init__.py`, increment the `__version__` string, e.g. `__version__ = '1.2.3'`.
+* Open `VERSION.txt`, increment the file content, e.g. `20.6.22`.
 * Run `make format`.
 * Run `towncrier` to update `CHANGELOG.md`.
 * Open `CHANGELOG.md`, make sure that the generated file content looks good. Fix it if needed.

--- a/VERSION.txt
+++ b/VERSION.txt
@@ -1,0 +1,4 @@
+# Global version number,
+# Update the file and run 'make fmt' to apply it everywhere
+
+20.6.10

--- a/build-tools/version.py
+++ b/build-tools/version.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+import abc
+import dataclasses
+import pathlib
+import re
+from typing import Dict
+
+import click
+
+
+class VersionProcessor(abc.ABC):
+    @abc.abstractmethod
+    def read(self, fname: pathlib.Path) -> str:
+        pass
+
+    @abc.abstractmethod
+    def write(self, fname: pathlib.Path, version: str) -> None:
+        pass
+
+
+class InitVP(VersionProcessor):
+    def read(self, fname: pathlib.Path) -> str:
+        txt = fname.read_text()
+        found = re.findall(r'^__version__ = "([^"]+)"\r?$', txt, re.M)
+        if not found:
+            raise click.ClickException(f"Unable to find version in {fname}.")
+        if len(found) > 1:
+            raise click.ClickException(f"Found multiple versions {found} in {fname}.")
+        return found[0]
+
+    def write(self, fname: pathlib.Path, version: str) -> None:
+        # Check for possible errors
+        old_version = self.read(fname)
+        txt = fname.read_text()
+        old = f'__version__ = "{old_version}"'
+        new = f'__version__ = "{version}"'
+        new_txt = txt.replace(old, new)
+        fname.write_text(new_txt)
+
+
+class SetupVP(VersionProcessor):
+    def read(self, fname: pathlib.Path) -> str:
+        txt = fname.read_text()
+        found = re.findall(r'^    version="([^"]+)",\r?$', txt, re.M)
+        if not found:
+            raise click.ClickException(f"Unable to find version in {fname}.")
+        if len(found) > 1:
+            raise click.ClickException(f"Found multiple versions {found} in {fname}.")
+        return found[0]
+
+    def write(self, fname: pathlib.Path, version: str) -> None:
+        # Check for possible errors
+        old_version = self.read(fname)
+        txt = fname.read_text()
+        old = f'    version="{old_version}",'
+        new = f'    version="{version}",'
+        new_txt = txt.replace(old, new)
+        fname.write_text(new_txt)
+
+
+FILES = {"neuromation/__init__.py": InitVP(), "setup.py": SetupVP()}
+
+
+@dataclasses.dataclass(frozen=True)
+class Config:
+    root: pathlib.Path
+    version: str
+    files: Dict[str, VersionProcessor]
+
+
+def find_root() -> pathlib.Path:
+    here = pathlib.Path.cwd()
+    while here.anchor != here:
+        git = here / ".git"
+        if git.exists() and git.is_dir():
+            return here
+        here = here.parent
+    raise click.ClickException(f"Project root is not found for {here}")
+
+
+def read_version(root: pathlib.Path) -> str:
+    version_file = root / "VERSION.txt"
+    txt = version_file.read_text()
+    found = []
+    for line in txt.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        found.append(line)
+    if not found:
+        raise click.ClickException(f"Version is not found in {version_file}")
+    if len(found) > 1:
+        raise click.ClickException(
+            f"Multiple versions {found} are not found in {version_file}"
+        )
+    return found[0]
+
+
+@click.group()
+@click.pass_context
+def main(ctx: click.Context):
+    """Version commands"""
+    root = find_root()
+    version = read_version(root)
+    files = {(root / fname): vp for fname, vp in FILES.items()}
+    for fname in files.keys():
+        if not fname.exists() or not fname.is_file():
+            raise click.ClickException(f"File {fname} doesn't exist")
+    ctx.obj = Config(root=root, version=version, files=files)
+
+
+@main.command()
+@click.pass_obj
+def check(cfg: Config):
+    """Check version"""
+    for fname, vp in cfg.files.items():
+        version = vp.read(fname)
+        if version != cfg.version:
+            raise click.ClickException(
+                f"File {fname} contains version {version} but expected {cfg.version}, "
+                "run './build-tools/version.py update' to fix the problem"
+            )
+
+
+@main.command()
+@click.pass_obj
+def update(cfg: Config):
+    """Update version"""
+    for fname, vp in cfg.files.items():
+        vp.write(fname, cfg.version)
+
+
+main()

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import re
-
 from setuptools import find_packages, setup
 
 
@@ -9,17 +7,9 @@ with open("README.md") as f:
     readme = f.read()
 
 
-with open("neuromation/__init__.py") as f:
-    txt = f.read()
-    try:
-        version = re.findall(r'^__version__ = "([^"]+)"\r?$', txt, re.M)[0]
-    except IndexError:
-        raise RuntimeError("Unable to determine version.")
-
-
 setup(
     name="neuromation",
-    version=version,
+    version="20.6.10",
     python_requires=">=3.6.0",
     # Make sure to pin versions of install_requires
     install_requires=[


### PR DESCRIPTION
It can help in future splitting `neuromation` package into sdk, cli, etc. -- all of them should be kept in the same github repo, share the same version number, and released all-at-once.