### PR TITLE
Enforce ANSI in less command

### DIFF
--- a/CHANGELOG.D/1595.bugfix
+++ b/CHANGELOG.D/1595.bugfix
@@ -1,0 +1,1 @@
+Always set "LESS=-R" env variable to fix outputs with scrolling, e.g. "neuro help"

--- a/neuromation/cli/utils.py
+++ b/neuromation/cli/utils.py
@@ -567,6 +567,9 @@ def pager_maybe(
             click.echo(line)
         return
 
+    # Enforce ANSI sequence handling (colors etc.)
+    os.environ["LESS"] = "-R"
+
     lines_it: Iterator[str] = iter(lines)
     count = int(terminal_size[1] * 2 / 3)
     handled = list(itertools.islice(lines_it, count))


### PR DESCRIPTION
Always set "LESS=-R" env variable to fix outputs with scrolling, e.g. "neuro help"