### PR TITLE
Feature/replace queued progress

### DIFF
--- a/neuromation/api/abc.py
+++ b/neuromation/api/abc.py
@@ -84,6 +84,37 @@ class AbstractRecursiveFileProgress(AbstractFileProgress):
         pass  # pragma: no cover
 
 
+# Next class for typing only (wrapped with queue_calls version of above classes)
+
+
+class _AsyncAbstractFileProgress(abc.ABC):
+    @abc.abstractmethod
+    async def start(self, data: StorageProgressStart) -> None:
+        pass  # pragma: no cover
+
+    @abc.abstractmethod
+    async def complete(self, data: StorageProgressComplete) -> None:
+        pass  # pragma: no cover
+
+    @abc.abstractmethod
+    async def step(self, data: StorageProgressStep) -> None:
+        pass  # pragma: no cover
+
+
+class _AsyncAbstractRecursiveFileProgress(_AsyncAbstractFileProgress):
+    @abc.abstractmethod
+    async def enter(self, data: StorageProgressEnterDir) -> None:
+        pass  # pragma: no cover
+
+    @abc.abstractmethod
+    async def leave(self, data: StorageProgressLeaveDir) -> None:
+        pass  # pragma: no cover
+
+    @abc.abstractmethod
+    async def fail(self, data: StorageProgressFail) -> None:
+        pass  # pragma: no cover
+
+
 # image
 
 

--- a/neuromation/api/utils.py
+++ b/neuromation/api/utils.py
@@ -17,7 +17,6 @@ from typing import (
     Tuple,
     Type,
     TypeVar,
-    cast,
 )
 
 import aiohttp
@@ -132,20 +131,20 @@ def find_project_root(path: Optional[Path] = None) -> Path:
     raise ConfigError(f"Project root is not found for {path}")
 
 
-class QueuedCall:
-    def __init__(
-        self, real_callable: Callable[..., Any], *args: Any, **kwargs: Any
-    ) -> None:
-        self._real_callable = real_callable
-        self._args = args
-        self._kwargs = kwargs
+QueuedCall = Callable[[], Any]
 
-    def execute(self) -> Any:
-        return self._real_callable(*self._args, **self._kwargs)
+
+async def _noop(*args: Any, **kwargs: Any) -> None:
+    pass
+
+
+class _NoopProxy:
+    def __getattr__(self, name: str) -> Callable[[Any], Coroutine[Any, Any, None]]:
+        return _noop
 
 
 def queue_calls(
-    any_obj: Any,
+    any_obj: Any, allow_any_for_none: bool = True,
 ) -> Tuple["asyncio.Queue[QueuedCall]", Any]:  # Sadly, but there is now way to annotate
     """Add calls to asyncio.Queue instead executing them directly
 
@@ -158,26 +157,31 @@ def queue_calls(
     queue, wrapped = queue_calls(Foo())
     await wrapped.bar("foo")
 
-    Will add QueuedCall(foo.bar, args=("foo",)) to the queue and will not print anything.
+    Will add QueuedCall(foo.bar, args=("foo",)) to the queue and will not print
+    anything.
 
     To execute calls, you can do next:
 
     queued_call = await queue.get()
     queued_call.execute()
+
+    In case `any_obj` is `None` and `allow_any_for_none` is set, then a proxy will not
+    raise any AttributeErrors and just absorb all cals silently.
     """
     queue: "asyncio.Queue[QueuedCall]" = asyncio.Queue()
 
     async def add_to_queue(
         real_method: Callable[..., None], *args: Any, **kwargs: Any
     ) -> None:
-        if not callable(real_method):
-            # Force TypeError
-            real_method()  # NOQA
-        await queue.put(QueuedCall(real_method, *args, **kwargs))
+        await queue.put(partial(real_method, *args, **kwargs))
 
     class Proxy:
-        def __getattr__(self, item: str) -> Callable[[Any], Coroutine[Any, Any, None]]:
-            real_method = getattr(any_obj, item)
+        def __getattr__(self, name: str) -> Callable[[Any], Coroutine[Any, Any, None]]:
+            real_method = getattr(any_obj, name)
+            setattr(self, name, partial(add_to_queue, real_method))
             return partial(add_to_queue, real_method)
+
+    if any_obj is None and allow_any_for_none:
+        return queue, _NoopProxy()
 
     return queue, Proxy()


### PR DESCRIPTION
Refactors out `QueuedProgress` to allow to use idea "store calls into `asyncio.Queue`" not only for `AbstractFileProgress` descendants.
Required for https://github.com/neuromation/platform-client-python/pull/1664