### PR TITLE
Remove "ALL" volumes option from commands help

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -463,7 +463,7 @@ Name | Description|
 |_\--schedule-timeout TIMEDELTA_|Optional job schedule timeout in the format '3m4s' \(some parts may be missing).|
 |_--tag TAG_|Optional job tag, multiple values allowed|
 |_\-t, --tty / -T, --no-tty_|Allocate a TTY, can be useful for interactive jobs. By default is on if the command is executed from a terminal, non-tty mode is used if executed from a script.|
-|_\-v, --volume MOUNT_|Mounts directory from vault into container. Use multiple options to mount more than one volume. Use --volume=ALL to mount all accessible storage directories. See `neuro help secrets` for information about passing secrets as mounted files.|
+|_\-v, --volume MOUNT_|Mounts directory from vault into container. Use multiple options to mount more than one volume. See `neuro help secrets` for information about passing secrets as mounted files.|
 |_\--wait-start / --no-wait-start_|Wait for a job start or failure  \[default: True]|
 |_\-w, --workdir TEXT_|Working directory inside the container|
 
@@ -1949,7 +1949,7 @@ Name | Description|
 |_\--schedule-timeout TIMEDELTA_|Optional job schedule timeout in the format '3m4s' \(some parts may be missing).|
 |_--tag TAG_|Optional job tag, multiple values allowed|
 |_\-t, --tty / -T, --no-tty_|Allocate a TTY, can be useful for interactive jobs. By default is on if the command is executed from a terminal, non-tty mode is used if executed from a script.|
-|_\-v, --volume MOUNT_|Mounts directory from vault into container. Use multiple options to mount more than one volume. Use --volume=ALL to mount all accessible storage directories. See `neuro help secrets` for information about passing secrets as mounted files.|
+|_\-v, --volume MOUNT_|Mounts directory from vault into container. Use multiple options to mount more than one volume. See `neuro help secrets` for information about passing secrets as mounted files.|
 |_\--wait-start / --no-wait-start_|Wait for a job start or failure  \[default: True]|
 |_\-w, --workdir TEXT_|Working directory inside the container|
 

--- a/neuromation/cli/job.py
+++ b/neuromation/cli/job.py
@@ -208,7 +208,6 @@ def job() -> None:
     help=(
         "Mounts directory from vault into container. "
         "Use multiple options to mount more than one volume. "
-        "Use --volume=ALL to mount all accessible storage directories."
     ),
     secure=True,
 )
@@ -889,7 +888,6 @@ async def kill(root: Root, jobs: Sequence[str]) -> None:
     help=(
         "Mounts directory from vault into container. "
         "Use multiple options to mount more than one volume. "
-        "Use --volume=ALL to mount all accessible storage directories. "
         "See `neuro help secrets` for information about "
         "passing secrets as mounted files."
     ),


### PR DESCRIPTION
This feature was removed in https://github.com/neuromation/platform-client-python/pull/1707, so we should remove id from options help strings.