### PR TITLE
Improve parsing of storage amount

### DIFF
--- a/CHANGELOG.D/1731.feature
+++ b/CHANGELOG.D/1731.feature
@@ -1,0 +1,2 @@
+Memory amount parsing now supports of both `b` and `B` suffixes for specifying decimal
+quantities. Improved `neuro disk create` docs.

--- a/CLI.md
+++ b/CLI.md
@@ -1907,7 +1907,7 @@ Name | Description|
 |Usage|Description|
 |---|---|
 | _[neuro disk ls](#neuro-disk-ls)_| List disks |
-| _[neuro disk create](#neuro-disk-create)_| Create disk with storage amount STORAGE |
+| _[neuro disk create](#neuro-disk-create)_| Create a disk with at least storage amount STORAGE |
 | _[neuro disk get](#neuro-disk-get)_| Get disk DISK_ID |
 | _[neuro disk rm](#neuro-disk-rm)_| Remove disk DISK_ID |
 
@@ -1936,7 +1936,7 @@ Name | Description|
 
 ### neuro disk create
 
-Create disk with storage amount STORAGE.<br/>
+Create a disk with at least storage amount STORAGE.<br/><br/>To specify the amount, you can use the following suffixes: "kKMGTPEZY" To<br/>use decimal quantities, append "b" or "B". For example: - 1K or 1k is 1024<br/>bytes - 1Kb or 1KB is 1000 bytes - 20G is 20 * 2 ^ 30 bytes - 20Gb or 20GB<br/>is 20.000.000.000 bytes<br/><br/>Note that server can have big granularity \(for example, 1G) so it will<br/>possibly round-up the amount you requested.<br/>
 
 **Usage:**
 
@@ -1948,8 +1948,8 @@ neuro disk create [OPTIONS] STORAGE
 
 ```bash
 
-neuro disk create 10Gi
-neuro disk create 500Mi
+neuro disk create 10G
+neuro disk create 500M
 
 ```
 

--- a/neuromation/cli/disks.py
+++ b/neuromation/cli/disks.py
@@ -38,7 +38,17 @@ async def ls(root: Root, full_uri: bool) -> None:
 @argument("storage")
 async def create(root: Root, storage: str) -> None:
     """
-    Create disk with storage amount STORAGE.
+    Create a disk with at least storage amount STORAGE.
+
+    To specify the amount, you can use the following suffixes: "kKMGTPEZY"
+    To use decimal quantities, append "b" or "B". For example:
+    - 1K or 1k is 1024 bytes
+    - 1Kb or 1KB is 1000 bytes
+    - 20G is 20 * 2 ^ 30 bytes
+    - 20Gb or 20GB is 20.000.000.000 bytes
+
+    Note that server can have big granularity (for example, 1G)
+    so it will possibly round-up the amount you requested.
 
     Examples:
 

--- a/neuromation/cli/parse_utils.py
+++ b/neuromation/cli/parse_utils.py
@@ -21,7 +21,7 @@ def parse_memory(memory: str) -> int:
     if not memory:
         raise value_error
 
-    pattern = r"^(?P<value>\d+)(?P<units>(kB|K)|((?P<prefix>[{prefixes}])(?P<unit>B?)))$".format(  # NOQA
+    pattern = r"^(?P<value>\d+)(?P<units>(kB|kb|K|k)|((?P<prefix>[{prefixes}])(?P<unit>[bB]?)))$".format(  # NOQA
         prefixes=prefixes
     )
     regex = re.compile(pattern)
@@ -37,10 +37,10 @@ def parse_memory(memory: str) -> int:
     prefix = groups["prefix"]
     units = groups["units"]
 
-    if units == "kB":
+    if units == "kB" or units == "kb":
         return value * 1000
 
-    if units == "K":
+    if units == "K" or units == "k":
         return value * 1024
 
     # Our prefix string starts with Mega

--- a/tests/cli/test_parse_utils.py
+++ b/tests/cli/test_parse_utils.py
@@ -17,29 +17,40 @@ def test_parse_memory() -> None:
 
     assert parse_memory("1K") == 1024
     assert parse_memory("2K") == 2048
+    assert parse_memory("1k") == 1024
+    assert parse_memory("2k") == 2048
     assert parse_memory("1kB") == 1000
     assert parse_memory("2kB") == 2000
+    assert parse_memory("1kb") == 1000
+    assert parse_memory("2kb") == 2000
 
     assert parse_memory("42M") == 42 * 1024 ** 2
     assert parse_memory("42MB") == 42 * 1000 ** 2
+    assert parse_memory("42Mb") == 42 * 1000 ** 2
 
     assert parse_memory("42G") == 42 * 1024 ** 3
     assert parse_memory("42GB") == 42 * 1000 ** 3
+    assert parse_memory("42Gb") == 42 * 1000 ** 3
 
     assert parse_memory("42T") == 42 * 1024 ** 4
     assert parse_memory("42TB") == 42 * 1000 ** 4
+    assert parse_memory("42Tb") == 42 * 1000 ** 4
 
     assert parse_memory("42P") == 42 * 1024 ** 5
     assert parse_memory("42PB") == 42 * 1000 ** 5
+    assert parse_memory("42Pb") == 42 * 1000 ** 5
 
     assert parse_memory("42E") == 42 * 1024 ** 6
     assert parse_memory("42EB") == 42 * 1000 ** 6
+    assert parse_memory("42Eb") == 42 * 1000 ** 6
 
     assert parse_memory("42Z") == 42 * 1024 ** 7
     assert parse_memory("42ZB") == 42 * 1000 ** 7
+    assert parse_memory("42Zb") == 42 * 1000 ** 7
 
     assert parse_memory("42Y") == 42 * 1024 ** 8
     assert parse_memory("42YB") == 42 * 1000 ** 8
+    assert parse_memory("42Yb") == 42 * 1000 ** 8
 
 
 def test_parse_columns_default() -> None:


### PR DESCRIPTION
Closes https://github.com/neuromation/platform-client-python/issues/1730
I tried to improve UX (by supporting both `b` and `B` prefixes) and documented format in command help.