### PR TITLE
Check URIs for allowed parts and support special characters in paths

### DIFF
--- a/CHANGELOG.D/1531.feature
+++ b/CHANGELOG.D/1531.feature
@@ -1,0 +1,2 @@
+Fragment, query, user, password and port parts are not allowed now in URIs (these parts were silently ignored before).
+Fixed support of local file paths containing characters like "#", "%", ":", "?", "@" and "~".

--- a/neuromation/api/parser.py
+++ b/neuromation/api/parser.py
@@ -106,7 +106,7 @@ class Parser(metaclass=NoPublicConstructor):
             raw_uri, container_path, read_only = self._parse_generic_volume(
                 volume, allow_rw_spec=True, resource_name="disk volume"
             )
-            disk_uri = self._parse_disk_resource(str(raw_uri))
+            disk_uri = self._parse_disk_resource(raw_uri)
             disk_volumes.append(DiskVolume(disk_uri, container_path, read_only))
         return disk_volumes
 

--- a/neuromation/api/parser.py
+++ b/neuromation/api/parser.py
@@ -6,7 +6,7 @@ from yarl import URL
 
 from .config import Config
 from .parsing_utils import LocalImage, RemoteImage, TagOption, _ImageNameParser
-from .url_utils import normalize_storage_path_uri, uri_from_cli
+from .url_utils import uri_from_cli
 from .utils import NoPublicConstructor
 
 
@@ -49,7 +49,7 @@ class Parser(metaclass=NoPublicConstructor):
 
     def _parse_generic_volume(
         self, volume: str, allow_rw_spec: bool = True, resource_name: str = "volume"
-    ) -> Tuple[URL, str, bool]:
+    ) -> Tuple[str, str, bool]:
         parts = volume.split(":")
         read_only = False
         if allow_rw_spec and len(parts) == 4:
@@ -59,13 +59,16 @@ class Parser(metaclass=NoPublicConstructor):
         elif len(parts) != 3:
             raise ValueError(f"Invalid {resource_name} specification '{volume}'")
         container_path = parts.pop()
-        raw_uri = URL(":".join(parts))
+        raw_uri = ":".join(parts)
         return raw_uri, container_path, read_only
 
     def volume(self, volume: str) -> Volume:
         raw_uri, container_path, read_only = self._parse_generic_volume(volume)
-        storage_uri = normalize_storage_path_uri(
-            raw_uri, self._config.username, self._config.cluster_name
+        storage_uri = uri_from_cli(
+            raw_uri,
+            self._config.username,
+            self._config.cluster_name,
+            allowed_schemes=("storage",),
         )
         return Volume(
             storage_uri=storage_uri, container_path=container_path, read_only=read_only
@@ -85,7 +88,7 @@ class Parser(metaclass=NoPublicConstructor):
             raw_uri, container_path, _ = self._parse_generic_volume(
                 volume, allow_rw_spec=False, resource_name="secret file"
             )
-            secret_uri = self._parse_secret_resource(str(raw_uri))
+            secret_uri = self._parse_secret_resource(raw_uri)
             secret_files.append(SecretFile(secret_uri, container_path))
         return secret_files
 

--- a/tests/api/test_images.py
+++ b/tests/api/test_images.py
@@ -230,10 +230,11 @@ class TestImageParser:
             "image:///ubuntu?key=value",
             "image:ubuntu?key=value",
             "image:5000?key=value",
+            "image://test-cluster/bob/ubuntu:v10.04?",
         ],
     )
     def test_parse_as_neuro_image__with_query__fail(self, url: str) -> None:
-        with pytest.raises(ValueError, match="query is not allowed"):
+        with pytest.raises(ValueError, match="Query part is not allowed in image URI"):
             self.parser.parse_as_neuro_image(url)
 
     @pytest.mark.parametrize(
@@ -244,25 +245,33 @@ class TestImageParser:
             "image:///ubuntu#fragment",
             "image:ubuntu#fragment",
             "image:5000#fragment",
+            "image://test-cluster/bob/ubuntu:v10.04#",
         ],
     )
     def test_parse_as_neuro_image__with_fragment__fail(self, url: str) -> None:
-        with pytest.raises(ValueError, match="fragment is not allowed"):
+        with pytest.raises(
+            ValueError, match="Fragment part is not allowed in image URI"
+        ):
             self.parser.parse_as_neuro_image(url)
 
     def test_parse_as_neuro_image__with_user__fail(self) -> None:
         url = "image://user@test-cluster/bob/ubuntu"
-        with pytest.raises(ValueError, match="user is not allowed"):
+        with pytest.raises(ValueError, match="User is not allowed in image URI"):
             self.parser.parse_as_neuro_image(url)
 
     def test_parse_as_neuro_image__with_password__fail(self) -> None:
         url = "image://:password@test-cluster/bob/ubuntu"
-        with pytest.raises(ValueError, match="password is not allowed"):
+        with pytest.raises(ValueError, match="Password is not allowed in image URI"):
+            self.parser.parse_as_neuro_image(url)
+
+    def test_parse_as_neuro_image__with_empty_password__fail(self) -> None:
+        url = "image://:@test-cluster/bob/ubuntu"
+        with pytest.raises(ValueError, match="Password is not allowed in image URI"):
             self.parser.parse_as_neuro_image(url)
 
     def test_parse_as_neuro_image__with_port__fail(self) -> None:
         url = "image://test-cluster:443/bob/ubuntu"
-        with pytest.raises(ValueError, match="port is not allowed"):
+        with pytest.raises(ValueError, match="Port is not allowed in image URI"):
             self.parser.parse_as_neuro_image(url)
 
     def test_parse_as_neuro_image_empty__fail(self) -> None:
@@ -578,6 +587,17 @@ class TestImageParser:
             registry="reg.neu.ro",
         )
 
+    def test_parse_as_neuro_image_with_scheme_special_chars(self) -> None:
+        image = "image://other-cluster/bob/ubuntu%23%25%3F%E2%82%AC:v10.04%23%25%3F%E2%82%AC"
+        parsed = self.parser.parse_as_neuro_image(image)
+        assert parsed == RemoteImage.new_neuro_image(
+            name="ubuntu#%?€",
+            tag="v10.04#%?€",
+            owner="bob",
+            cluster_name="other-cluster",
+            registry="reg.neu.ro",
+        )
+
     def test_parse_as_neuro_image_no_scheme_no_slash_no_tag_fail(self) -> None:
         image = "ubuntu"
         with pytest.raises(ValueError, match="scheme 'image:' is required"):
@@ -616,6 +636,18 @@ class TestImageParser:
     def test_parse_as_neuro_image_with_registry_prefix(self) -> None:
         image = self.parser.parse_as_neuro_image("reg.neu.ro/user/image:tag")
         assert str(image) == "image://test-cluster/user/image:tag"
+
+    def test_parse_as_neuro_image_with_registry_prefix_special_chars(self) -> None:
+        image = self.parser.parse_as_neuro_image(
+            "reg.neu.ro/user/image%23%25%3F%E2%82%AC:tag%23%25%3F%E2%82%AC"
+        )
+        assert image == RemoteImage.new_neuro_image(
+            name="image#%?€",
+            tag="tag#%?€",
+            owner="user",
+            cluster_name="test-cluster",
+            registry="reg.neu.ro",
+        )
 
     def test_parse_as_neuro_image_no_scheme_3_slash_with_tag_fail(self) -> None:
         image = "something/docker.io/library/ubuntu:v10.04"

--- a/tests/api/test_images.py
+++ b/tests/api/test_images.py
@@ -588,11 +588,11 @@ class TestImageParser:
         )
 
     def test_parse_as_neuro_image_with_scheme_special_chars(self) -> None:
-        image = "image://other-cluster/bob/ubuntu%23%25%3F%E2%82%AC:v10.04%23%25%3F%E2%82%AC"
+        image = "image://other-cluster/bob/ubuntu%23%25%3F%C3%9F:v10.04%23%25%3F%C3%9F"
         parsed = self.parser.parse_as_neuro_image(image)
         assert parsed == RemoteImage.new_neuro_image(
-            name="ubuntu#%?€",
-            tag="v10.04#%?€",
+            name="ubuntu#%?ß",
+            tag="v10.04#%?ß",
             owner="bob",
             cluster_name="other-cluster",
             registry="reg.neu.ro",
@@ -639,11 +639,11 @@ class TestImageParser:
 
     def test_parse_as_neuro_image_with_registry_prefix_special_chars(self) -> None:
         image = self.parser.parse_as_neuro_image(
-            "reg.neu.ro/user/image%23%25%3F%E2%82%AC:tag%23%25%3F%E2%82%AC"
+            "reg.neu.ro/user/image%23%25%3F%C3%9F:tag%23%25%3F%C3%9F"
         )
         assert image == RemoteImage.new_neuro_image(
-            name="image#%?€",
-            tag="tag#%?€",
+            name="image#%?ß",
+            tag="tag#%?ß",
             owner="user",
             cluster_name="test-cluster",
             registry="reg.neu.ro",

--- a/tests/api/test_parser.py
+++ b/tests/api/test_parser.py
@@ -105,34 +105,34 @@ async def test_parse_volumes(make_client: _MakeClient) -> None:
 async def test_parse_volumes_special_chars(make_client: _MakeClient) -> None:
     async with make_client("https://example.com") as client:
         volumes_str = [
-            "storage://cluster/user/path/to%23%25%3a%3f%40%E2%82%AC:/storage/location:rw",
-            "secret://cluster/user/secret%23%25%3a%3f%40%E2%82%AC:/secret/location",
-            "disk://cluster/user/disk%23%25%3a%3f%40%E2%82%AC:/disk/location:rw",
+            "storage://cluster/user/path/to%23%25%3a%3f%40%C3%9F:/storage/location:rw",
+            "secret://cluster/user/secret%23%25%3a%3f%40%C3%9F:/secret/location",
+            "disk://cluster/user/disk%23%25%3a%3f%40%C3%9F:/disk/location:rw",
         ]
         result = client.parse.volumes(volumes_str)
         assert result.volumes == [
             Volume(
-                URL("storage://cluster/user/path/to%23%25%3a%3f%40%E2%82%AC"),
+                URL("storage://cluster/user/path/to%23%25%3a%3f%40%C3%9F"),
                 "/storage/location",
                 False,
             ),
         ]
-        assert result.volumes[0].storage_uri.path == "/user/path/to#%:?@€"
+        assert result.volumes[0].storage_uri.path == "/user/path/to#%:?@ß"
         assert result.secret_files == [
             SecretFile(
-                URL("secret://cluster/user/secret%23%25%3a%3f%40%E2%82%AC"),
+                URL("secret://cluster/user/secret%23%25%3a%3f%40%C3%9F"),
                 "/secret/location",
             )
         ]
-        assert result.secret_files[0].secret_uri.path == "/user/secret#%:?@€"
+        assert result.secret_files[0].secret_uri.path == "/user/secret#%:?@ß"
         assert result.disk_volumes == [
             DiskVolume(
-                URL("disk://cluster/user/disk%23%25%3a%3f%40%E2%82%AC"),
+                URL("disk://cluster/user/disk%23%25%3a%3f%40%C3%9F"),
                 "/disk/location",
                 False,
             ),
         ]
-        assert result.disk_volumes[0].disk_uri.path == "/user/disk#%:?@€"
+        assert result.disk_volumes[0].disk_uri.path == "/user/disk#%:?@ß"
 
 
 async def test_parse_local(make_client: _MakeClient) -> None:

--- a/tests/api/test_url_utils.py
+++ b/tests/api/test_url_utils.py
@@ -92,16 +92,16 @@ def test_uri_from_cli_absolute_file_uri() -> None:
 
 def test_uri_from_cli_relative_file_uri_special_chars() -> None:
     uri = uri_from_cli(
-        "file:path/to/file%23%25%3f:@~%E2%82%AC", "testuser", "test-cluster"
+        "file:path/to/file%23%25%3f:@~%C3%9F", "testuser", "test-cluster"
     )
-    assert uri.path.endswith("/path/to/file#%?:@~€")
+    assert uri.path.endswith("/path/to/file#%?:@~ß")
 
 
 def test_uri_from_cli_absolute_file_uri_special_chars() -> None:
     uri = uri_from_cli(
-        "file:/path/to/file%23%25%3f:@~%E2%82%AC", "testuser", "test-cluster"
+        "file:/path/to/file%23%25%3f:@~%C3%9F", "testuser", "test-cluster"
     )
-    assert uri.path.endswith("/path/to/file#%?:@~€")
+    assert uri.path.endswith("/path/to/file#%?:@~ß")
 
 
 def test_uri_from_cli_relative_storage_uri() -> None:
@@ -122,11 +122,11 @@ def test_uri_from_cli_absolute_storage_uri() -> None:
 
 def test_uri_from_cli_absolute_storage_uri_special_chars() -> None:
     uri = uri_from_cli(
-        "storage://cluster/user/path/to/file%23%25%3f:@~%E2%82%AC",
+        "storage://cluster/user/path/to/file%23%25%3f:@~%C3%9F",
         "testuser",
         "test-cluster",
     )
-    assert uri.path == "/user/path/to/file#%?:@~€"
+    assert uri.path == "/user/path/to/file#%?:@~ß"
 
 
 def test_uri_from_cli_numberic_path() -> None:

--- a/tests/api/test_url_utils.py
+++ b/tests/api/test_url_utils.py
@@ -56,7 +56,7 @@ def test_uri_from_cli_relative_path_special_chars() -> None:
 
 def test_uri_from_cli_absolute_path_special_chars() -> None:
     uri = uri_from_cli("/path/to/file#%23:?@~", "testuser", "test-cluster")
-    assert uri.path == "/path/to/file#%23:?@~"
+    assert _extract_path(uri) == Path("/path/to/file#%23:?@~").absolute()
 
 
 def test_uri_from_cli_path_with_tilde(fake_homedir: Path) -> None:


### PR DESCRIPTION
* Fragment, query, user, password and port parts are not allowed now
  in URIs. Only allowed parts are scheme, host and path.
* Supported characters like "%", "#", "?", "@", ":", "~" in local file paths.

Closes #1531