### PR TITLE
Show a deprecation warning for --life-span=0

### DIFF
--- a/CHANGELOG.D/1749.feature
+++ b/CHANGELOG.D/1749.feature
@@ -1,0 +1,1 @@
+Show a deprecation warning for `--life-span=0`.

--- a/neuromation/cli/utils.py
+++ b/neuromation/cli/utils.py
@@ -9,6 +9,7 @@ import re
 import shlex
 import shutil
 import sys
+import warnings
 from datetime import timedelta
 from typing import (
     Any,
@@ -647,6 +648,13 @@ async def calc_life_span(
     )
     seconds = delta.total_seconds()
     if seconds == 0:
+        warnings.warn(
+            "Zero job's life-span (--life-span=0) is deprecated "
+            "and will be removed in the future neuro CLI release,"
+            "use a positive value to avoid the resource leakage",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return None
     assert seconds > 0
     return seconds

--- a/neuromation/cli/utils.py
+++ b/neuromation/cli/utils.py
@@ -651,7 +651,7 @@ async def calc_life_span(
         warnings.warn(
             "Zero job's life-span (--life-span=0) is deprecated "
             "and will be removed in the future neuro CLI release,"
-            "use a positive value to avoid the resource leakage",
+            "use a positive value to avoid resource leakage",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -676,7 +676,11 @@ async def test_calc_life_span_none_default(
 
 async def test_calc_life_span_zero(make_client: _MakeClient) -> None:
     async with make_client("https://example.com") as client:
-        assert await calc_life_span(client, "0", "1d", "job") is None
+        with pytest.warns(
+            DeprecationWarning,
+            match=r"Zero job's life-span \(--life-span=0\) is deprecated",
+        ):
+            assert await calc_life_span(client, "0", "1d", "job") is None
 
 
 async def test_calc_life_span_default_life_span_all_keys(


### PR DESCRIPTION
An explicit positive value should be passed to avoid resource leakage.

The value could be arbitrarily big, feel free to pass `365d` if it is required really.