### PR TITLE
Change the color scheme for job statuses

### DIFF
--- a/CHANGELOG.D/1752.feature
+++ b/CHANGELOG.D/1752.feature
@@ -1,0 +1,1 @@
+Change the color scheme for job statuses. The yellow color is for the cancellation, cyan is for pending jobs.

--- a/neuromation/cli/formatters/jobs.py
+++ b/neuromation/cli/formatters/jobs.py
@@ -26,12 +26,12 @@ from .utils import ImageFormatter, URIFormatter, image_formatter
 
 
 COLORS = {
-    JobStatus.PENDING: "yellow",
+    JobStatus.PENDING: "cyan",
     JobStatus.RUNNING: "blue",
     JobStatus.SUCCEEDED: "green",
-    JobStatus.CANCELLED: "green",
+    JobStatus.CANCELLED: "yellow",
     JobStatus.FAILED: "red",
-    JobStatus.UNKNOWN: "yellow",
+    JobStatus.UNKNOWN: "bright_red",
 }
 
 


### PR DESCRIPTION
The yellow color is for the cancellation, cyan is for pending status.